### PR TITLE
#22 농구장 제보 버튼, UI 

### DIFF
--- a/src/app/map/CourtReport.tsx
+++ b/src/app/map/CourtReport.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import {
+  Textarea,
+  Input,
+  Select,
+  RadioGroup,
+  Radio,
+  SelectItem,
+  Button,
+} from '@nextui-org/react';
+import { IoIosClose } from 'react-icons/io';
+import { basketballCourtType, basketballCourtSize } from './courtReportData';
+
+interface CourtReportProps {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+const CourtReport: React.FC<CourtReportProps> = ({ isVisible, onClose }) => {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <div
+      className={`absolute inset-0 top-4 z-20
+      m-auto h-fit w-9/12 rounded-lg bg-white p-5 shadow-md ${isVisible ? '' : 'hidden'}`}
+    >
+      <Button
+        isIconOnly
+        className="bg-gradient absolute right-4 top-4"
+        onClick={onClose}
+        aria-label="Close"
+      >
+        <IoIosClose size={22} />
+      </Button>
+      <div className="flex flex-col gap-4">
+        <p className="text-center text-lg font-semibold">농구장 제보하기</p>
+        <Input
+          isRequired
+          labelPlacement="outside"
+          variant="bordered"
+          type="string"
+          label="농구장명"
+          placeholder="농구장명을 입력해주세요."
+        />
+        <div className="flex gap-4 md:flex-nowrap">
+          <Select
+            labelPlacement="outside"
+            label="코트 종류"
+            placeholder="코트 종류"
+            variant="bordered"
+            className="max-w-xs"
+          >
+            {basketballCourtType.map((courtType) => (
+              <SelectItem key={courtType.value} value={courtType.value}>
+                {courtType.value}
+              </SelectItem>
+            ))}
+          </Select>
+          <Select
+            labelPlacement="outside"
+            label="코트 사이즈"
+            placeholder="코트 사이즈"
+            variant="bordered"
+            className="max-w-xs"
+          >
+            {basketballCourtSize.map((courtSize) => (
+              <SelectItem key={courtSize.value} value={courtSize.value}>
+                {courtSize.value}
+              </SelectItem>
+            ))}
+          </Select>
+        </div>
+
+        <Input
+          labelPlacement="outside"
+          variant="bordered"
+          type="number"
+          label="골대 수"
+          placeholder="골대 수"
+          className="mb-4"
+        />
+        <RadioGroup label="야간 조명" orientation="horizontal">
+          <Radio value="있음">있음</Radio>
+          <Radio value="없음">없음</Radio>
+        </RadioGroup>
+        <RadioGroup label="개방 시간" orientation="horizontal">
+          <Radio value="제한">제한</Radio>
+          <Radio value="24시">24시</Radio>
+        </RadioGroup>
+        <RadioGroup label="사용료" orientation="horizontal">
+          <Radio value="무료">무료</Radio>
+          <Radio value="유료">유료</Radio>
+        </RadioGroup>
+        <RadioGroup label="주차여부" orientation="horizontal">
+          <Radio value="가능">가능</Radio>
+          <Radio value="불가능">불가능</Radio>
+        </RadioGroup>
+        <div className="w-full">
+          <Textarea
+            maxRows={4}
+            variant="bordered"
+            label="기타 정보"
+            placeholder="해당 농구장에 관한 기타 정보를 입력해주세요."
+            value={value}
+            onValueChange={setValue}
+          />
+        </div>
+        <Button
+          aria-label="제보하기"
+          type="button"
+          className="bg-primary text-white"
+        >
+          제보하기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CourtReport;

--- a/src/app/map/KakaoMap.tsx
+++ b/src/app/map/KakaoMap.tsx
@@ -5,6 +5,7 @@ import { Button } from '@nextui-org/button';
 import { IoSearchSharp } from 'react-icons/io5';
 import { MdMyLocation } from 'react-icons/md';
 import { BiSolidLocationPlus } from 'react-icons/bi';
+import CourtReport from './CourtReport';
 
 declare global {
   interface Window {
@@ -21,6 +22,7 @@ const KakaoMap: FC = () => {
   const [selectedPlace, setSelectedPlace] = useState<any>(null);
   const [, setIsLoading] = useState<boolean>(true);
   const [mapLevel] = useState(3); // 초기 확대 레벨 설정
+  const [isCourtReportVisible, setIsCourtReportVisible] = useState(false);
 
   useEffect(() => {
     const loadKakaoMap = () => {
@@ -66,6 +68,10 @@ const KakaoMap: FC = () => {
     } else {
       alert('사용자 위치 정보가 설정되지 않았습니다.');
     }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(e.target.value);
   };
 
   const handleSearch = () => {
@@ -152,10 +158,18 @@ const KakaoMap: FC = () => {
     }
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       handleSearch();
     }
+  };
+
+  const showCourtReport = () => {
+    setIsCourtReportVisible(true);
+  };
+
+  const hideCourtReport = () => {
+    setIsCourtReportVisible(false);
   };
 
   return (
@@ -166,8 +180,8 @@ const KakaoMap: FC = () => {
           placeholder="장소 검색"
           className="flex-grow rounded-md border-0 p-2 focus:outline-none focus:ring-0"
           value={searchKeyword}
-          onChange={(e) => setSearchKeyword(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onChange={handleSearchChange}
+          onKeyDown={handleKeyDown}
         />
         <button
           aria-label="Search"
@@ -178,7 +192,14 @@ const KakaoMap: FC = () => {
           <IoSearchSharp size={20} className="text-gray-400 hover:text-black" />
         </button>
       </div>
-      <div ref={mapRef} className="w-ful relative h-[calc(100vh-109px)]" />
+      <div ref={mapRef} className="relative h-[calc(100vh-109px)] w-full">
+        {isCourtReportVisible && (
+          <CourtReport
+            isVisible={isCourtReportVisible}
+            onClose={hideCourtReport}
+          />
+        )}
+      </div>
       <div className="absolute bottom-10 right-6 z-10 flex flex-col items-end gap-y-3">
         <Button
           isIconOnly
@@ -194,16 +215,16 @@ const KakaoMap: FC = () => {
           aria-label="Court Report"
           type="button"
           className="justify-center rounded-full bg-primary text-white shadow-md"
-          onClick={moveToLocation}
+          onClick={showCourtReport}
         >
           농구장 제보
         </Button>
       </div>
       {selectedPlace && (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
         <div
           ref={modalRef}
-          className="fixed left-0 top-0 z-10 flex h-full w-full items-center justify-center bg-black bg-opacity-50"
+          className="fixed left-0 top-0 z-40 flex h-full w-full items-center justify-center bg-black bg-opacity-50"
           onClick={closeModal}
           style={{ display: 'none' }}
         >

--- a/src/app/map/KakaoMap.tsx
+++ b/src/app/map/KakaoMap.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React, { FC, useEffect, useRef, useState } from 'react';
+import { Button } from '@nextui-org/button';
 import { IoSearchSharp } from 'react-icons/io5';
 import { MdMyLocation } from 'react-icons/md';
-import { Button } from '@nextui-org/button';
+import { BiSolidLocationPlus } from 'react-icons/bi';
 
 declare global {
   interface Window {
@@ -177,8 +178,8 @@ const KakaoMap: FC = () => {
           <IoSearchSharp size={20} className="text-gray-400 hover:text-black" />
         </button>
       </div>
-      <div ref={mapRef} className="relative h-[calc(100vh-109px)] w-full" />
-      <div className="absolute bottom-10 right-6 z-10">
+      <div ref={mapRef} className="w-ful relative h-[calc(100vh-109px)]" />
+      <div className="absolute bottom-10 right-6 z-10 flex flex-col items-end gap-y-3">
         <Button
           isIconOnly
           aria-label="Current Location"
@@ -187,6 +188,15 @@ const KakaoMap: FC = () => {
           onClick={moveToLocation}
         >
           <MdMyLocation size={22} className="text-white" />
+        </Button>
+        <Button
+          startContent={<BiSolidLocationPlus size={20} />}
+          aria-label="Court Report"
+          type="button"
+          className="justify-center rounded-full bg-primary text-white shadow-md"
+          onClick={moveToLocation}
+        >
+          농구장 제보
         </Button>
       </div>
       {selectedPlace && (

--- a/src/app/map/KakaoMap.tsx
+++ b/src/app/map/KakaoMap.tsx
@@ -3,6 +3,7 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
 import { IoSearchSharp } from 'react-icons/io5';
 import { MdMyLocation } from 'react-icons/md';
+import { Button } from '@nextui-org/button';
 
 declare global {
   interface Window {
@@ -178,14 +179,15 @@ const KakaoMap: FC = () => {
       </div>
       <div ref={mapRef} className="relative h-[calc(100vh-109px)] w-full" />
       <div className="absolute bottom-10 right-6 z-10">
-        <button
+        <Button
+          isIconOnly
           aria-label="Current Location"
           type="button"
-          className="flex h-10 w-10 items-center justify-center rounded-full bg-primary shadow-md"
+          className="justify-center rounded-full bg-primary shadow-md"
           onClick={moveToLocation}
         >
           <MdMyLocation size={22} className="text-white" />
-        </button>
+        </Button>
       </div>
       {selectedPlace && (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions

--- a/src/app/map/courtReportData.ts
+++ b/src/app/map/courtReportData.ts
@@ -1,0 +1,15 @@
+export const basketballCourtType = [
+  {
+    value: '흙',
+  },
+  {
+    value: '우레탄',
+  },
+  { value: '아스팔트' },
+  { value: '고무' },
+  { value: '폴리프로필렌(PP)' },
+  { value: '마루' },
+  { value: '알 수 없음' },
+];
+
+export const basketballCourtSize = [{ value: '풀코트' }, { value: '반코트' }];

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import KakaoMap from '../components/KakaoMap';
+import KakaoMap from './KakaoMap';
 
 const Map = () => <KakaoMap />;
 


### PR DESCRIPTION
## 📝 작업 내용

> 농구장 제보 버튼으로 제보 모달이 열리도록 구현했습니다. 추후 서버와 연결, 자세한 이벤트 조작 필요.

- [x]  농구장 제보 버튼
- [x]  농구장 제보받기 UI
(정보: 코트 종류, 실내/야외, 코트사이즈, 골대수, 야간 조명, 개방시간, 사용료, 주차 가능, 기타 정보)

### 스크린샷
![스크린샷 2024-01-19 오후 3 58 11](https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/f7e61fb4-8c36-426c-af37-ae559b37291f)

## 💬 참고사항
- Footer z-index가 30으로 설정되어 있어 그 위에 모달을 띄우려면 z-40으로 설정하면 됩니다.
- 현재 농구장명만 입력 필수로 설정해놨습니다.

## 참고하면 좋은 자료
https://react-spectrum.adobe.com/react-stately/collections.html
https://nextui.org/docs/components/select