### PR TITLE
#8 커뮤니티 기능 로컬 스토리지를 이용해 완성

### DIFF
--- a/src/app/community/[tag]/layout.tsx
+++ b/src/app/community/[tag]/layout.tsx
@@ -2,16 +2,15 @@
 
 import React from 'react';
 import { Button } from '@nextui-org/button';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { FaPlus } from 'react-icons/fa';
 import { IoSearchSharp } from 'react-icons/io5';
 
-import { Tab, Tabs } from '@nextui-org/react';
 import Page from './page';
 
 const Layout = () => {
   const router = useRouter();
-  const pathname = usePathname();
+
   return (
     <div className="flex flex-col">
       <div className="z-10 flex w-full transform items-center justify-center rounded-md bg-background p-1 shadow-md">
@@ -28,17 +27,56 @@ const Layout = () => {
         </button>
       </div>
       <div className="flex justify-center space-x-10">
-        <Tabs aria-label="Options" selectedKey={pathname}>
-          <Tab key="all" title="전체" href="/community/all" />
-          <Tab key="free" title="자유" href="/community/free" />
-          <Tab href="/community/usedtrade" key="usedtrade" title="중고거래" />
-          <Tab href="/community/question" key="question" title="질문" />
-          <Tab
-            href="/community/rentaltransfer"
-            key="rentaltransfer"
-            title="대관양도"
-          />
-        </Tabs>
+        <Button
+          key="all"
+          radius="full"
+          className="rounded-lg border border-slate-200 bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          onClick={() => {
+            router.push('/community/all');
+          }}
+        >
+          전체
+        </Button>
+        <Button
+          key="free"
+          radius="full"
+          className="rounded-lg border border-slate-200 bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          onClick={() => {
+            router.push('/community/free');
+          }}
+        >
+          자유
+        </Button>
+        <Button
+          key="usedtrade"
+          radius="full"
+          className="rounded-lg border border-slate-200 bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          onClick={() => {
+            router.push('/community/usedtrade');
+          }}
+        >
+          중고거래
+        </Button>
+        <Button
+          key="question"
+          radius="full"
+          className="rounded-lg border border-slate-200 bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          onClick={() => {
+            router.push('/community/question');
+          }}
+        >
+          질문
+        </Button>
+        <Button
+          key="rentaltransfer"
+          radius="full"
+          className="rounded-lg border border-slate-200 bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          onClick={() => {
+            router.push('/community/rentaltransfer');
+          }}
+        >
+          대관양도
+        </Button>
       </div>
 
       <Page />

--- a/src/app/community/[tag]/layout.tsx
+++ b/src/app/community/[tag]/layout.tsx
@@ -50,18 +50,21 @@ const Layout = () => {
       <input className="border-solid" placeholder="검색어를 입력해주세요" />
 
       <Page />
-
-      <Button
-        aria-label="Write new post"
-        type="button"
-        startContent={<FaPlus />}
-        className="justify-center rounded-full bg-primary text-white shadow-md"
-        onClick={() => {
-          router.push('/community/write');
-        }}
-      >
-        글 작성하기
-      </Button>
+      <div className="fixed bottom-14 w-full max-w-[600px]">
+        <div className="mr-4 flex justify-end">
+          <Button
+            aria-label="Write new post"
+            type="button"
+            startContent={<FaPlus />}
+            className="rounded-full bg-primary text-white shadow-md"
+            onClick={() => {
+              router.push('/community/write');
+            }}
+          >
+            글 작성하기
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/app/community/[tag]/layout.tsx
+++ b/src/app/community/[tag]/layout.tsx
@@ -1,54 +1,46 @@
 'use client';
 
-import Link from 'next/link';
 import React from 'react';
 import { Button } from '@nextui-org/button';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { FaPlus } from 'react-icons/fa';
+import { IoSearchSharp } from 'react-icons/io5';
+
+import { Tab, Tabs } from '@nextui-org/react';
 import Page from './page';
 
 const Layout = () => {
   const router = useRouter();
-
+  const pathname = usePathname();
   return (
-    <div className="flex h-svh flex-col">
+    <div className="flex flex-col">
       <div className="flex justify-center space-x-10">
-        <Link
-          className="h-8 w-16 rounded-md  border-2 border-solid border-gray-300 text-center"
-          href="/community/all"
-        >
-          전체
-        </Link>
-        <Link
-          className="h-8 w-16 rounded-md  border-2 border-solid border-gray-300	text-center"
-          href="/community/free"
-        >
-          자유
-        </Link>
-
-        <Link
-          className="h-8 w-16 rounded-md  border-2 border-solid border-gray-300	text-center"
-          href="/community/usedtrade"
-        >
-          중고 거래
-        </Link>
-
-        <Link
-          className="h-8 w-16 rounded-md  border-2 border-solid border-gray-300	 text-center"
-          href="/community/question"
-        >
-          질문
-        </Link>
-
-        <Link
-          className="h-8 w-16 rounded-md  border-2 border-solid border-gray-300	 text-center"
-          href="/community/rentaltransfer"
-        >
-          대관 양도
-        </Link>
+        <Tabs aria-label="Options" selectedKey={pathname}>
+          <Tab key="all" title="전체" href="/community/all" />
+          <Tab key="free" title="자유" href="/community/free" />
+          <Tab href="/community/usedtrade" key="usedtrade" title="중고거래" />
+          <Tab href="/community/question" key="question" title="질문" />
+          <Tab
+            href="/community/rentaltransfer"
+            key="rentaltransfer"
+            title="대관양도"
+          />
+        </Tabs>
       </div>
-      <input className="border-solid" placeholder="검색어를 입력해주세요" />
 
+      <div className="z-10 flex w-full transform items-center justify-center rounded-md bg-background p-1 shadow-md">
+        <input
+          placeholder="검색어를 입력해주세요"
+          className="w-11/12 p-2 focus:outline-none focus:ring-0"
+        />
+        <button
+          type="button"
+          aria-label="search button in community"
+          className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
+        >
+          <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
+        </button>
+      </div>
       <Page />
       <div className="fixed bottom-14 w-full max-w-[600px]">
         <div className="mr-4 flex justify-end">

--- a/src/app/community/[tag]/layout.tsx
+++ b/src/app/community/[tag]/layout.tsx
@@ -14,6 +14,19 @@ const Layout = () => {
   const pathname = usePathname();
   return (
     <div className="flex flex-col">
+      <div className="z-10 flex w-full transform items-center justify-center rounded-md bg-background p-1 shadow-md">
+        <input
+          placeholder="검색어를 입력해주세요"
+          className="w-11/12 p-2 focus:outline-none focus:ring-0"
+        />
+        <button
+          type="button"
+          aria-label="search button in community"
+          className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
+        >
+          <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
+        </button>
+      </div>
       <div className="flex justify-center space-x-10">
         <Tabs aria-label="Options" selectedKey={pathname}>
           <Tab key="all" title="전체" href="/community/all" />
@@ -28,19 +41,6 @@ const Layout = () => {
         </Tabs>
       </div>
 
-      <div className="z-10 flex w-full transform items-center justify-center rounded-md bg-background p-1 shadow-md">
-        <input
-          placeholder="검색어를 입력해주세요"
-          className="w-11/12 p-2 focus:outline-none focus:ring-0"
-        />
-        <button
-          type="button"
-          aria-label="search button in community"
-          className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
-        >
-          <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
-        </button>
-      </div>
       <Page />
       <div className="fixed bottom-14 w-full max-w-[600px]">
         <div className="mr-4 flex justify-end">

--- a/src/app/community/[tag]/layout.tsx
+++ b/src/app/community/[tag]/layout.tsx
@@ -26,7 +26,7 @@ const Layout = () => {
           <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
         </button>
       </div>
-      <div className="flex justify-center space-x-10">
+      <div className="my-3 flex justify-center space-x-10">
         <Button
           key="all"
           radius="full"

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -1,10 +1,31 @@
 'use client';
 
-import { Listbox, ListboxItem } from '@nextui-org/react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from '@nextui-org/react';
 import { useParams, useRouter } from 'next/navigation';
 
 import React, { useState, useEffect } from 'react';
 // TODO: 게시글 페이지, 게시판, 작성 페이지 , 댓글
+
+interface ICommunityItem {
+  id: number;
+  userId: string;
+  title: string;
+  content: string;
+  tag: string;
+  comment?: {
+    id: string;
+    postId: string;
+    userId: string;
+    content: string;
+  }[];
+}
 
 const Page = () => {
   const router = useRouter();
@@ -13,6 +34,7 @@ const Page = () => {
     {
       id: 1,
       title: '농구화 추천해주세요',
+      userId: 'user-1',
       content: '농구화 추천 좀 해주세요~~',
       tag: 'question',
       comment: [
@@ -26,6 +48,7 @@ const Page = () => {
     },
     {
       id: 2,
+      userId: 'user-2',
       title: '헤어밴드 팝니다',
       content: '나이키 헤어밴드입니다. 착감 거의 없습니다~~',
       tag: 'usedtrade',
@@ -40,42 +63,39 @@ const Page = () => {
       setData(JSON.parse(dummyData));
     }
   }, [data]);
-  const LinkHandler = (e: React.MouseEvent<HTMLLIElement>) => {
-    router.push(`/community/board/${e.currentTarget.value}`);
+  const handleLink = (id: number) => {
+    router.push(`/community/article/${id}`);
   };
   return (
-    <Listbox color="warning">
-      {params.tag === 'all'
-        ? data.map((item) => (
-            <ListboxItem
-              onClick={LinkHandler}
-              className="h-4/5"
-              key={item.id}
-              value={item.id}
-              aria-labelledby={`title-${item.id}`}
-            >
-              {item.title}
-            </ListboxItem>
-          ))
-        : data
-            .filter((item) => item.tag === params.tag)
-            .map((item) => (
-              <ListboxItem key={item.id}>{item.title}</ListboxItem>
-            ))}
-    </Listbox>
+    <Table color="primary">
+      <TableHeader>
+        <TableColumn>TITLE</TableColumn>
+        <TableColumn>USER</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {params.tag === 'all'
+          ? data.map((item) => (
+              <TableRow
+                className="cursor-pointer hover:bg-primary hover:text-white"
+                onClick={() => handleLink(item.id)}
+                key={item.id}
+                aria-labelledby={`title-${item.id}`}
+              >
+                <TableCell className="flex-grow">{item.title}</TableCell>
+                <TableCell>{item.userId}</TableCell>
+              </TableRow>
+            ))
+          : data
+              .filter((item) => item.tag === params.tag)
+              .map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell className="flex-grow">{item.title}</TableCell>
+                  <TableCell>{item.userId}</TableCell>
+                </TableRow>
+              ))}
+      </TableBody>
+    </Table>
   );
 };
 
 export default Page;
-interface ICommunityItem {
-  id: number;
-  title: string;
-  content: string;
-  tag: string;
-  comment?: {
-    id: string;
-    postId: string;
-    userId: string;
-    content: string;
-  }[];
-}

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -15,6 +15,14 @@ const Page = () => {
       title: '농구화 추천해주세요',
       content: '농구화 추천 좀 해주세요~~',
       tag: 'quetion',
+      comment: [
+        {
+          id: 'c1',
+          userId: 'user-1',
+          postId: '1',
+          content: '농구화 추천해드렸습니다~',
+        },
+      ],
     },
     {
       id: 2,
@@ -63,4 +71,12 @@ interface ICommunityItem {
   title: string;
   content: string;
   tag: string;
+  comment?: [
+    {
+      id: string;
+      postId: string;
+      userId: string;
+      content: string;
+    },
+  ];
 }

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -14,7 +14,7 @@ const Page = () => {
       id: 1,
       title: '농구화 추천해주세요',
       content: '농구화 추천 좀 해주세요~~',
-      tag: 'quetion',
+      tag: 'question',
       comment: [
         {
           id: 'c1',

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -29,6 +29,7 @@ const Page = () => {
       title: '헤어밴드 팝니다',
       content: '나이키 헤어밴드입니다. 착감 거의 없습니다~~',
       tag: 'usedtrade',
+      comment: [],
     },
   ]);
 
@@ -71,12 +72,10 @@ interface ICommunityItem {
   title: string;
   content: string;
   tag: string;
-  comment?: [
-    {
-      id: string;
-      postId: string;
-      userId: string;
-      content: string;
-    },
-  ];
+  comment?: {
+    id: string;
+    postId: string;
+    userId: string;
+    content: string;
+  }[];
 }

--- a/src/app/community/article/[id]/[edit]/page.tsx
+++ b/src/app/community/article/[id]/[edit]/page.tsx
@@ -4,8 +4,14 @@ import { Button } from '@nextui-org/button';
 import { useParams, useRouter } from 'next/navigation';
 import { IoIosArrowBack } from 'react-icons/io';
 import { FaHeart } from 'react-icons/fa';
-
 import React, { useState } from 'react';
+
+interface ICommunityItem {
+  id: number;
+  title: string;
+  content: string;
+  tag: string;
+}
 
 const Page = () => {
   const router = useRouter();
@@ -17,7 +23,7 @@ const Page = () => {
   );
   const [editedTitle, setEditedTitle] = useState('');
   const [editedContent, setEditedContent] = useState('');
-  const editorHandler = () => {
+  const HandleEditor = () => {
     matchedData.title = editedTitle === '' ? matchedData.title : editedTitle;
     matchedData.content =
       editedContent !== '' ? matchedData.content : editedContent;
@@ -29,7 +35,7 @@ const Page = () => {
     });
     localStorage.setItem('community', JSON.stringify(communityData));
   };
-  const deleteHandler = () => {
+  const handelDelete = () => {
     communityData.splice(matchedData.id - 1, 1);
     localStorage.setItem('community', JSON.stringify(communityData));
   };
@@ -72,13 +78,13 @@ const Page = () => {
               <div>
                 <Button
                   onClick={() => {
-                    editorHandler();
+                    HandleEditor();
                     router.push(`/community/board/${params.id}`);
                   }}
                 >
                   수정 완료
                 </Button>
-                <Button onClick={deleteHandler}>삭제</Button>
+                <Button onClick={handelDelete}>삭제</Button>
               </div>
             </div>
           </div>
@@ -91,10 +97,3 @@ const Page = () => {
 };
 
 export default Page;
-
-interface ICommunityItem {
-  id: number;
-  title: string;
-  content: string;
-  tag: string;
-}

--- a/src/app/community/article/[id]/page.tsx
+++ b/src/app/community/article/[id]/page.tsx
@@ -2,11 +2,27 @@
 
 import { Button } from '@nextui-org/button';
 import { useParams, useRouter } from 'next/navigation';
-import { IoIosArrowBack } from 'react-icons/io';
+import { Avatar } from '@nextui-org/react';
+import { IoChevronBackSharp } from 'react-icons/io5';
 import { FaHeart } from 'react-icons/fa';
 
 import React, { useState } from 'react';
 import CommentList from '../../components/commentList';
+
+interface ICommunityItem {
+  id: number;
+  title: string;
+  content: string;
+  tag: string;
+  comment: [
+    {
+      id: number;
+      postId: string;
+      userId: string;
+      content: string;
+    },
+  ];
+}
 
 const Page = () => {
   const router = useRouter();
@@ -35,42 +51,57 @@ const Page = () => {
   };
 
   return (
-    <div>
+    <div className="h-[90vh]">
       {matchedData ? (
         <div>
-          <div className="flex items-center justify-center border-b-2">
-            <Button
-              className="flex-none rounded-md focus:outline-none"
-              isIconOnly
-              color="default"
-              variant="ghost"
+          <div className="flex h-[50px] items-center justify-center border-b-2">
+            <IoChevronBackSharp
+              cursor="pointer"
+              size={24}
               onClick={() => {
                 router.push('/community/all');
               }}
-            >
-              <IoIosArrowBack className="text-gray-600 hover:text-black" />
-            </Button>
-
+            />
             <h1 className="flex-grow text-center">{matchedData.title}</h1>
           </div>
 
-          <div className="flex h-40 flex-col justify-between border-b-2">
-            <p>{matchedData.content}</p>
-            <div className="flex justify-between">
-              <Button aria-label="like button" variant="ghost" isIconOnly>
-                <FaHeart />
-              </Button>
-              <div>
-                <Button
-                  variant="ghost"
-                  className=""
-                  onClick={() => {
-                    router.push(`/community/board/${params.id}/edit`);
-                  }}
-                >
-                  수정
-                </Button>
-                <Button variant="ghost">삭제</Button>
+          <div className="flex h-[295px] flex-col">
+            <div aria-label="contentsCard">
+              <div
+                aria-label="유저 아바타"
+                className="mt-1 flex items-center justify-start border-b-1"
+              >
+                <Avatar
+                  name={matchedData.userId}
+                  className="me-2 border-3 border-primary"
+                />
+                <p className="text-lg	">{matchedData.userId}</p>
+              </div>
+
+              <div className="h-[200px] border-b-2">
+                <p aria-label="게시글 컨텐츠" className="m-2">
+                  {matchedData.content}
+                </p>
+              </div>
+
+              <div className="flex justify-between">
+                <div className="m-1 text-lg text-danger">
+                  <FaHeart aria-label="like button" />
+                </div>
+                <div aria-label="수정 삭제 버튼 그룹">
+                  <button
+                    type="button"
+                    className="hover:text-primary"
+                    onClick={() => {
+                      router.push(`/community/article/${params.id}/edit`);
+                    }}
+                  >
+                    수정
+                  </button>
+                  <button type="button" className="ml-3 hover:text-primary">
+                    삭제
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -84,9 +115,7 @@ const Page = () => {
               }}
             />
             <Button
-              variant="ghost"
-              className="w-[10px]"
-              type="button"
+              className="w-[10px] hover:bg-primary hover:text-white"
               onClick={CommentHandler}
             >
               입력
@@ -102,18 +131,3 @@ const Page = () => {
 };
 
 export default Page;
-
-interface ICommunityItem {
-  id: number;
-  title: string;
-  content: string;
-  tag: string;
-  comment: [
-    {
-      id: number;
-      postId: string;
-      userId: string;
-      content: string;
-    },
-  ];
-}

--- a/src/app/community/board/[id]/[edit]/page.tsx
+++ b/src/app/community/board/[id]/[edit]/page.tsx
@@ -18,8 +18,9 @@ const Page = () => {
   const [editedTitle, setEditedTitle] = useState('');
   const [editedContent, setEditedContent] = useState('');
   const editorHandler = () => {
-    matchedData.title = editedTitle;
-    matchedData.content = editedContent;
+    matchedData.title = editedTitle === '' ? matchedData.title : editedTitle;
+    matchedData.content =
+      editedContent !== '' ? matchedData.content : editedContent;
     communityData.splice(matchedData.id - 1, 1, {
       id: matchedData.id,
       title: editedTitle,
@@ -81,7 +82,6 @@ const Page = () => {
               </div>
             </div>
           </div>
-          <input placeholder="댓글을 입력해주세요" />
         </div>
       ) : (
         <p>404 not found</p>

--- a/src/app/community/board/[id]/page.tsx
+++ b/src/app/community/board/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { IoIosArrowBack } from 'react-icons/io';
 import { FaHeart } from 'react-icons/fa';
 
-import React from 'react';
+import React, { useState } from 'react';
 import CommentList from '../../components/commentList';
 
 const Page = () => {
@@ -16,7 +16,23 @@ const Page = () => {
   const matchedData = communityData.find(
     (item: ICommunityItem) => item.id === Number(params.id)
   );
-
+  const [comment, setComment] = useState('');
+  const CommentHandler = () => {
+    if (comment !== '') {
+      const newComment = {
+        id: 2,
+        postId: params.id,
+        userId: 'user123',
+        content: comment,
+      };
+      matchedData.comment.push(newComment);
+      const updatedData = communityData.map((item: ICommunityItem) =>
+        item.id === matchedData.id ? matchedData : item
+      );
+      localStorage.setItem('community', JSON.stringify(updatedData));
+      setComment('');
+    }
+  };
   return (
     <div>
       {matchedData ? (
@@ -54,7 +70,16 @@ const Page = () => {
               </div>
             </div>
           </div>
-          <input placeholder="댓글을 입력해주세요" />
+          <input
+            placeholder="댓글을 입력해주세요"
+            value={comment}
+            onChange={(e) => {
+              setComment(e.target.value);
+            }}
+          />
+          <button type="button" onClick={CommentHandler}>
+            입력
+          </button>
           <CommentList />
         </div>
       ) : (

--- a/src/app/community/board/[id]/page.tsx
+++ b/src/app/community/board/[id]/page.tsx
@@ -40,14 +40,15 @@ const Page = () => {
         <div>
           <div className="flex items-center justify-center border-b-2">
             <Button
-              className="flex-none border-2"
+              className="flex-none rounded-md focus:outline-none"
               isIconOnly
               color="default"
+              variant="ghost"
               onClick={() => {
                 router.push('/community/all');
               }}
             >
-              <IoIosArrowBack />
+              <IoIosArrowBack className="text-gray-600 hover:text-black" />
             </Button>
 
             <h1 className="flex-grow text-center">{matchedData.title}</h1>
@@ -56,31 +57,41 @@ const Page = () => {
           <div className="flex h-40 flex-col justify-between border-b-2">
             <p>{matchedData.content}</p>
             <div className="flex justify-between">
-              <Button isIconOnly>
+              <Button aria-label="like button" variant="ghost" isIconOnly>
                 <FaHeart />
               </Button>
               <div>
                 <Button
+                  variant="ghost"
+                  className=""
                   onClick={() => {
                     router.push(`/community/board/${params.id}/edit`);
                   }}
                 >
                   수정
                 </Button>
-                <Button>삭제</Button>
+                <Button variant="ghost">삭제</Button>
               </div>
             </div>
           </div>
-          <input
-            placeholder="댓글을 입력해주세요"
-            value={comment}
-            onChange={(e) => {
-              setComment(e.target.value);
-            }}
-          />
-          <button type="button" onClick={CommentHandler}>
-            입력
-          </button>
+          <div className="flex">
+            <input
+              placeholder="댓글을 입력해주세요"
+              className="w-11/12 rounded-md bg-background p-1 p-2 shadow-md focus:outline-none focus:ring-0"
+              value={comment}
+              onChange={(e) => {
+                setComment(e.target.value);
+              }}
+            />
+            <Button
+              variant="ghost"
+              className="w-[10px]"
+              type="button"
+              onClick={CommentHandler}
+            >
+              입력
+            </Button>
+          </div>
           <CommentList />
         </div>
       ) : (

--- a/src/app/community/board/[id]/page.tsx
+++ b/src/app/community/board/[id]/page.tsx
@@ -33,6 +33,7 @@ const Page = () => {
       setComment('');
     }
   };
+
   return (
     <div>
       {matchedData ? (

--- a/src/app/community/board/[id]/page.tsx
+++ b/src/app/community/board/[id]/page.tsx
@@ -6,6 +6,7 @@ import { IoIosArrowBack } from 'react-icons/io';
 import { FaHeart } from 'react-icons/fa';
 
 import React from 'react';
+import CommentList from '../../components/commentList';
 
 const Page = () => {
   const router = useRouter();
@@ -54,6 +55,7 @@ const Page = () => {
             </div>
           </div>
           <input placeholder="댓글을 입력해주세요" />
+          <CommentList />
         </div>
       ) : (
         <p>404 not found</p>
@@ -69,4 +71,12 @@ interface ICommunityItem {
   title: string;
   content: string;
   tag: string;
+  comment: [
+    {
+      id: number;
+      postId: string;
+      userId: string;
+      content: string;
+    },
+  ];
 }

--- a/src/app/community/board/page.tsx
+++ b/src/app/community/board/page.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-const Page = () => {
-  const title = 'hello';
-  return <div>{title}</div>;
-};
-
-export default Page;

--- a/src/app/community/components/commentItem.tsx
+++ b/src/app/community/components/commentItem.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+const CommentItem: React.FC<ICommentItemProps> = ({ comment, onEdit }) => {
+  const [editToggle, setEditToggle] = useState(false);
+  const [editedComment, setEditedComment] = useState(comment.content);
+  const editHandler = () => {
+    setEditToggle(!editToggle);
+    if (editToggle) {
+      onEdit(comment.id, editedComment);
+      setEditedComment('');
+      setEditToggle(false);
+    }
+  };
+  return (
+    <div key={comment.id}>
+      {editToggle ? (
+        <input
+          placeholder={comment.content}
+          value={editedComment}
+          onChange={(e) => {
+            setEditedComment(e.target.value);
+          }}
+        />
+      ) : (
+        <h2>{comment.content}</h2>
+      )}
+      <button type="button" onClick={editHandler}>
+        수정
+      </button>
+      <button type="button">삭제</button>
+    </div>
+  );
+};
+
+export default CommentItem;
+
+interface ICommentItemProps {
+  comment: {
+    id: string;
+    postId: string;
+    userId: string;
+    content: string;
+  };
+  onEdit: (id: string, editedComment: string) => void;
+}

--- a/src/app/community/components/commentItem.tsx
+++ b/src/app/community/components/commentItem.tsx
@@ -19,7 +19,7 @@ const CommentItem: React.FC<ICommentItemProps> = ({
     onDelete(comment.id);
   };
   return (
-    <div key={comment.id}>
+    <div key={comment.id} className="border-gray flex border-b-2">
       {editToggle ? (
         <input
           placeholder={comment.content}
@@ -29,14 +29,24 @@ const CommentItem: React.FC<ICommentItemProps> = ({
           }}
         />
       ) : (
-        <h2>{comment.content}</h2>
+        <h2 className="w-[500px]">{comment.content}</h2>
       )}
-      <button type="button" onClick={editHandler}>
-        수정
-      </button>
-      <button type="button" onClick={deleteHandler}>
-        삭제
-      </button>
+      <div>
+        <button
+          className="text-gray-600 hover:text-danger"
+          type="button"
+          onClick={editHandler}
+        >
+          수정
+        </button>
+        <button
+          type="button"
+          className="mx-3 text-gray-600 hover:text-danger"
+          onClick={deleteHandler}
+        >
+          삭제
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/community/components/commentItem.tsx
+++ b/src/app/community/components/commentItem.tsx
@@ -1,58 +1,5 @@
 import React, { useState } from 'react';
 
-const CommentItem: React.FC<ICommentItemProps> = ({
-  comment,
-  onEdit,
-  onDelete,
-}) => {
-  const [editToggle, setEditToggle] = useState(false);
-  const [editedComment, setEditedComment] = useState(comment.content);
-  const editHandler = () => {
-    setEditToggle(!editToggle);
-    if (editToggle) {
-      onEdit(comment.id, editedComment);
-      setEditedComment('');
-      setEditToggle(false);
-    }
-  };
-  const deleteHandler = () => {
-    onDelete(comment.id);
-  };
-  return (
-    <div key={comment.id} className="border-gray flex border-b-2">
-      {editToggle ? (
-        <input
-          placeholder={comment.content}
-          value={editedComment}
-          onChange={(e) => {
-            setEditedComment(e.target.value);
-          }}
-        />
-      ) : (
-        <h2 className="w-[500px]">{comment.content}</h2>
-      )}
-      <div>
-        <button
-          className="text-gray-600 hover:text-danger"
-          type="button"
-          onClick={editHandler}
-        >
-          수정
-        </button>
-        <button
-          type="button"
-          className="mx-3 text-gray-600 hover:text-danger"
-          onClick={deleteHandler}
-        >
-          삭제
-        </button>
-      </div>
-    </div>
-  );
-};
-
-export default CommentItem;
-
 interface ICommentItemProps {
   comment: {
     id: string;
@@ -63,3 +10,60 @@ interface ICommentItemProps {
   onEdit: (id: string, editedComment: string) => void;
   onDelete: (id: string) => void;
 }
+
+const CommentItem: React.FC<ICommentItemProps> = ({
+  comment,
+  onEdit,
+  onDelete,
+}) => {
+  const [editToggle, setEditToggle] = useState(false);
+  const [editedComment, setEditedComment] = useState(comment.content);
+  const handleEdit = () => {
+    setEditToggle(!editToggle);
+    if (editToggle) {
+      onEdit(comment.id, editedComment);
+      setEditedComment('');
+      setEditToggle(false);
+    }
+  };
+  const handleDelete = () => {
+    onDelete(comment.id);
+  };
+  return (
+    <div
+      key={comment.id}
+      className="border-gray mt-2 flex items-center border-b-2"
+    >
+      <p className="m-2 w-14 text-sm">{comment.userId}</p>
+      {editToggle ? (
+        <input
+          placeholder={comment.content}
+          value={editedComment}
+          onChange={(e) => {
+            setEditedComment(e.target.value);
+          }}
+        />
+      ) : (
+        <h2 className="ml-2 mt-2 h-10 w-[750px]">{comment.content}</h2>
+      )}
+      <div aria-label="comment button group" className="w-40">
+        <button
+          className="text-gray-600 hover:text-primary"
+          type="button"
+          onClick={handleEdit}
+        >
+          수정
+        </button>
+        <button
+          type="button"
+          className="mx-3 text-gray-600 hover:text-primary"
+          onClick={handleDelete}
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CommentItem;

--- a/src/app/community/components/commentItem.tsx
+++ b/src/app/community/components/commentItem.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 
-const CommentItem: React.FC<ICommentItemProps> = ({ comment, onEdit }) => {
+const CommentItem: React.FC<ICommentItemProps> = ({
+  comment,
+  onEdit,
+  onDelete,
+}) => {
   const [editToggle, setEditToggle] = useState(false);
   const [editedComment, setEditedComment] = useState(comment.content);
   const editHandler = () => {
@@ -10,6 +14,9 @@ const CommentItem: React.FC<ICommentItemProps> = ({ comment, onEdit }) => {
       setEditedComment('');
       setEditToggle(false);
     }
+  };
+  const deleteHandler = () => {
+    onDelete(comment.id);
   };
   return (
     <div key={comment.id}>
@@ -27,7 +34,9 @@ const CommentItem: React.FC<ICommentItemProps> = ({ comment, onEdit }) => {
       <button type="button" onClick={editHandler}>
         수정
       </button>
-      <button type="button">삭제</button>
+      <button type="button" onClick={deleteHandler}>
+        삭제
+      </button>
     </div>
   );
 };
@@ -42,4 +51,5 @@ interface ICommentItemProps {
     content: string;
   };
   onEdit: (id: string, editedComment: string) => void;
+  onDelete: (id: string) => void;
 }

--- a/src/app/community/components/commentList.tsx
+++ b/src/app/community/components/commentList.tsx
@@ -2,6 +2,30 @@ import { useParams } from 'next/navigation';
 import React from 'react';
 import CommentItem from './commentItem';
 
+interface ICommunityItem {
+  id: number;
+  title: string;
+  content: string;
+  tag: string;
+  comment?: [
+    {
+      id: string;
+      postId: string;
+      userId: string;
+      content: string;
+    },
+  ];
+}
+interface ICommentItemProps {
+  id: string;
+  postId: string;
+  userId: string;
+  content: string;
+
+  onEdit: (id: string, editedComment: string) => void;
+  onDelete: (id: string, editedComment: string) => void;
+}
+
 const CommentList = () => {
   const params = useParams();
   const dummyData = localStorage.getItem('community');
@@ -9,7 +33,7 @@ const CommentList = () => {
   const matchedData = communityData.find(
     (item: ICommunityItem) => item.id === Number(params.id)
   );
-  const editCommentHandler = (id: string, editedComment: string) => {
+  const handleEditComment = (id: string, editedComment: string) => {
     const newComment = {
       id: 2,
       postId: params.id,
@@ -42,7 +66,7 @@ const CommentList = () => {
         <CommentItem
           key={i.id}
           comment={i}
-          onEdit={editCommentHandler}
+          onEdit={handleEditComment}
           onDelete={deleteCommentHandler}
         />
       ))}
@@ -51,27 +75,3 @@ const CommentList = () => {
 };
 
 export default CommentList;
-
-interface ICommunityItem {
-  id: number;
-  title: string;
-  content: string;
-  tag: string;
-  comment?: [
-    {
-      id: string;
-      postId: string;
-      userId: string;
-      content: string;
-    },
-  ];
-}
-interface ICommentItemProps {
-  id: string;
-  postId: string;
-  userId: string;
-  content: string;
-
-  onEdit: (id: string, editedComment: string) => void;
-  onDelete: (id: string, editedComment: string) => void;
-}

--- a/src/app/community/components/commentList.tsx
+++ b/src/app/community/components/commentList.tsx
@@ -8,11 +8,14 @@ const CommentList = () => {
   const matchedData = communityData.find(
     (item: ICommunityItem) => item.id === Number(params.id)
   );
-  console.log(matchedData.comment);
   return (
     <div>
-      {matchedData.comment.map((i: ICommunityItem) => (
-        <li>{i.content}</li>
+      {matchedData.comment?.map((i: ICommunityItem) => (
+        <div key={i.id}>
+          <h2>{i.content}</h2>
+          <button type="button">수정</button>
+          <button type="button">삭제</button>
+        </div>
       ))}
     </div>
   );

--- a/src/app/community/components/commentList.tsx
+++ b/src/app/community/components/commentList.tsx
@@ -1,0 +1,36 @@
+import { useParams } from 'next/navigation';
+import React from 'react';
+
+const CommentList = () => {
+  const params = useParams();
+  const dummyData = localStorage.getItem('community');
+  const communityData = dummyData ? JSON.parse(dummyData) : [];
+  const matchedData = communityData.find(
+    (item: ICommunityItem) => item.id === Number(params.id)
+  );
+  console.log(matchedData.comment);
+  return (
+    <div>
+      {matchedData.comment.map((i: ICommunityItem) => (
+        <li>{i.content}</li>
+      ))}
+    </div>
+  );
+};
+
+export default CommentList;
+
+interface ICommunityItem {
+  id: number;
+  title: string;
+  content: string;
+  tag: string;
+  comment?: [
+    {
+      id: string;
+      postId: string;
+      userId: string;
+      content: string;
+    },
+  ];
+}

--- a/src/app/community/components/commentList.tsx
+++ b/src/app/community/components/commentList.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'next/navigation';
 import React from 'react';
+import CommentItem from './commentItem';
 
 const CommentList = () => {
   const params = useParams();
@@ -8,14 +9,24 @@ const CommentList = () => {
   const matchedData = communityData.find(
     (item: ICommunityItem) => item.id === Number(params.id)
   );
+  const editCommentHandler = (id: string, editedComment: string) => {
+    const newComment = {
+      id: 2,
+      postId: params.id,
+      userId: 'user123',
+      content: editedComment,
+    };
+    matchedData.comment.splice(newComment.id - 1, 1, newComment);
+    const updatedData = communityData.map((item: ICommunityItem) =>
+      item.id === matchedData.id ? matchedData : item
+    );
+    localStorage.setItem('community', JSON.stringify(updatedData));
+  };
+
   return (
     <div>
-      {matchedData.comment?.map((i: ICommunityItem) => (
-        <div key={i.id}>
-          <h2>{i.content}</h2>
-          <button type="button">수정</button>
-          <button type="button">삭제</button>
-        </div>
+      {matchedData.comment?.map((i: ICommentItemProps) => (
+        <CommentItem key={i.id} comment={i} onEdit={editCommentHandler} />
       ))}
     </div>
   );
@@ -36,4 +47,12 @@ interface ICommunityItem {
       content: string;
     },
   ];
+}
+interface ICommentItemProps {
+  id: string;
+  postId: string;
+  userId: string;
+  content: string;
+
+  onEdit: (id: string, editedComment: string) => void;
 }

--- a/src/app/community/components/commentList.tsx
+++ b/src/app/community/components/commentList.tsx
@@ -22,11 +22,29 @@ const CommentList = () => {
     );
     localStorage.setItem('community', JSON.stringify(updatedData));
   };
+  const deleteCommentHandler = (id: string) => {
+    matchedData.comment = matchedData.comment?.filter(
+      (comment: any) => comment.id !== id
+    );
+    const updatedData = [...communityData];
 
+    const matchedIndex = updatedData.findIndex(
+      (item: ICommunityItem) => item.id === matchedData.id
+    );
+    if (matchedIndex !== -1) {
+      updatedData[matchedIndex] = matchedData;
+    }
+    localStorage.setItem('community', JSON.stringify(updatedData));
+  };
   return (
     <div>
       {matchedData.comment?.map((i: ICommentItemProps) => (
-        <CommentItem key={i.id} comment={i} onEdit={editCommentHandler} />
+        <CommentItem
+          key={i.id}
+          comment={i}
+          onEdit={editCommentHandler}
+          onDelete={deleteCommentHandler}
+        />
       ))}
     </div>
   );
@@ -55,4 +73,5 @@ interface ICommentItemProps {
   content: string;
 
   onEdit: (id: string, editedComment: string) => void;
+  onDelete: (id: string, editedComment: string) => void;
 }

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -25,13 +25,13 @@ const Page = () => {
   >([]); // test code
 
   const router = useRouter();
-  const titleHandler = (e: ChangeEvent<HTMLInputElement>) => {
+  const handelTitle = (e: ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
   };
   const contentHandler = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setContent(e.target.value);
   };
-  const tagHandler = (key: Key) => {
+  const handleTag = (key: Key) => {
     if (key === '자유') {
       setTag('free');
     }
@@ -53,7 +53,7 @@ const Page = () => {
   const handleSelectionChange = (keys: Selection) => {
     setSelectedKeys(new Set<string>(Array.from(keys).map(String)));
   };
-  const submitHandler = () => {
+  const handleSubmit = () => {
     setTitle('');
     setContent('');
     const storeData: { title: string; content: string; tag: string } = {
@@ -77,7 +77,7 @@ const Page = () => {
             <Button variant="bordered">{selectedValue}</Button>
           </DropdownTrigger>
           <DropdownMenu
-            onAction={tagHandler}
+            onAction={handleTag}
             aria-label="Static Actions"
             selectionMode="single"
             selectedKeys={selectedKeys}
@@ -102,7 +102,7 @@ const Page = () => {
           <button
             className="font-bold text-orange-600"
             type="button"
-            onClick={submitHandler}
+            onClick={handleSubmit}
           >
             작성완료
           </button>
@@ -113,7 +113,7 @@ const Page = () => {
         className="border-b border-solid border-gray-200"
         placeholder="title"
         value={title}
-        onChange={titleHandler}
+        onChange={handelTitle}
       />
       <textarea
         className="h-48 border-b border-solid border-gray-200"


### PR DESCRIPTION
## 📝 작업 내용

> 커뮤니티에 필요한 우선순위 상 기능 구현

- [x] 게시글 crud
- [x] 댓글 crud 

### 스크린샷 
- ~~nextUI Tabs 를 사용해 태그변경 기능 추가,버튼 피드백~~

- pr 피드백 이후 검색 위치 조정 & 게시글 리스트 tabs -> table
<img width="603" alt="스크린샷 2024-01-24 오후 11 45 46" src="https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/5f182b71-6546-48b2-bc1b-fd4e42da9157">

- ~~hover 시 색상 변화~~

- pr 피드백 이후 유저 정보 칸 생성 & 뒤로가기 버튼없이 아이콘
<img width="603" alt="스크린샷 2024-01-24 오후 11 46 08" src="https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/f4b1193c-b109-4b6d-bcd0-3053cf61f137">



## 💬 리뷰 요구사항 
- path 형태
  - 게시판 : http://localhost:3000/community/[tag] 
  - 게시글 : ~~http://localhost:3000/community/board/[id]~~ http://localhost:3000/community/article/[id] 로 수정
  - 게시글 수정 : http://localhost:3000/community/board/[id]/edit

- 👀 같이 리뷰 필요 
   - 스타일 관련해서 피드백 환영합니다!
   - 아직 유저 정보와 서버같은 다른 데이터 연동은 구현하지않은 점 감안해주세요