### PR TITLE
#52 로그인 상태 관리 - 토큰 저장 로직 수정

### DIFF
--- a/src/app/(auth)/login/email/page.tsx
+++ b/src/app/(auth)/login/email/page.tsx
@@ -5,8 +5,6 @@ import { Button, Input } from '@nextui-org/react';
 import { validateEmail, validatePassword } from '@/utils/validations';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { AxiosError } from 'axios';
-import axiosInstance from '@/app/api/axiosInstance';
 import useAuthStore from '@/store/authStore';
 import { EyeSlashFilledIcon } from './EyeSlashFilledIcon';
 import { EyeFilledIcon } from './EyeFilledIcon';
@@ -16,7 +14,7 @@ const EmailLogin = () => {
   const [isVisible, setIsVisible] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { setAccessToken, setLoggedIn } = useAuthStore();
+  const { login } = useAuthStore();
 
   const isEmailInvalid = useMemo(
     () => !validateEmail(email) && email !== '',
@@ -34,33 +32,15 @@ const EmailLogin = () => {
     }
 
     try {
-      const response = await axiosInstance.post('/api/login', {
-        email,
-        password,
-      });
+      await login(email, password);
 
-      if (response.status === 200) {
-        const { accessToken } = response.data;
-        setAccessToken(accessToken);
-        setLoggedIn(true);
-
-        alert('로그인 성공!');
-        router.push('/');
-      }
+      alert('로그인 성공!');
+      router.push('/');
     } catch (error) {
-      if (error instanceof AxiosError) {
-        const message =
-          error.response?.data?.message ||
-          '죄송합니다. 로그인에 실패했습니다. 서버 오류 발생.';
-        alert(message);
-      } else {
-        alert('죄송합니다. 알 수 없는 오류가 발생했습니다.');
-      }
+      console.error('로그인 실패:', error);
     }
   };
-
   const toggleVisibility = () => setIsVisible(!isVisible);
-
   return (
     <div className="mt-14 flex h-full w-full flex-col flex-wrap justify-center gap-3 p-5 align-middle md:flex-nowrap">
       <h1 className="mb-4 text-2xl font-bold sm:text-xl">

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,19 +1,32 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NextUIProvider } from '@nextui-org/react';
 import { ThemeProvider } from 'next-themes';
+import useAuthStore from '@/store/authStore';
 
-const Providers = ({ children }: { children: React.ReactNode }) => (
-  <NextUIProvider>
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="dark"
-      themes={['light', 'dark']}
-    >
-      {children}
-    </ThemeProvider>
-  </NextUIProvider>
-);
+const Providers = ({ children }: { children: React.ReactNode }) => {
+  const { setAccessToken } = useAuthStore();
+
+  useEffect(() => {
+    // 페이지 로딩 시 토큰을 가져와서 로그인 상태를 설정
+    const accessToken = localStorage.getItem('slam');
+    if (accessToken) {
+      setAccessToken(accessToken);
+    }
+  }, [setAccessToken]); // setAccessToken을 의존성으로 추가하여 변화할 때마다 호출
+
+  return (
+    <NextUIProvider>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="dark"
+        themes={['light', 'dark']}
+      >
+        {children}
+      </ThemeProvider>
+    </NextUIProvider>
+  );
+};
 
 export default Providers;

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,17 +1,66 @@
 import { create } from 'zustand';
+import LocalStorage from '@/utils/localstorage';
+import axiosInstance, { storeAccessToken } from '@/app/api/axiosInstance';
 
 interface AuthState {
   accessToken: string | null;
   isLoggedIn: boolean;
   setAccessToken: (token: string | null) => void;
-  setLoggedIn: (loggedIn: boolean) => void;
+  login: (email: string, password: string) => void;
+  logout: () => void;
 }
 
-const useAuthStore = create<AuthState>((set) => ({
-  accessToken: null,
-  isLoggedIn: false,
-  setAccessToken: (token) => set({ accessToken: token }),
-  setLoggedIn: (loggedIn) => set({ isLoggedIn: loggedIn }),
-}));
+const useAuthStore = create<AuthState>((set) => {
+  // isLoggedIn 값을 LocalStorage에서 가져와서 명시적으로 boolean으로 변환
+  const isLoggedIn = LocalStorage.getItem('isLoggedIn') === 'true';
+
+  return {
+    accessToken: LocalStorage.getItem('slam') || null,
+    isLoggedIn,
+    setAccessToken: (token) => {
+      if (token) {
+        LocalStorage.setItem('slam', token);
+        set({ accessToken: token, isLoggedIn: true });
+        // isLoggedIn 값을 로컬 스토리지에 저장
+        LocalStorage.setItem('isLoggedIn', 'true');
+      } else {
+        LocalStorage.removeItem('slam');
+        set({ accessToken: null, isLoggedIn: false });
+        // isLoggedIn 값을 로컬 스토리지에서 제거
+        LocalStorage.removeItem('isLoggedIn');
+      }
+    },
+    login: async (email, password) => {
+      try {
+        const response = await axiosInstance.post('/api/login', {
+          email,
+          password,
+        });
+
+        if (response.status === 200) {
+          const { accessToken } = response.data;
+
+          // 로그인 성공 시 토큰을 저장하고 상태를 업데이트
+          storeAccessToken(accessToken);
+          set({ accessToken, isLoggedIn: true });
+
+          // isLoggedIn 값을 로컬 스토리지에 저장
+          LocalStorage.setItem('isLoggedIn', 'true');
+        }
+      } catch (error) {
+        // 에러 처리 로직
+        console.error('로그인 실패:', error);
+        throw error;
+      }
+    },
+    logout: () => {
+      // 로그아웃 처리 로직 추가
+      // 예: 로그아웃 API 호출 후 setAccessToken 호출
+      // 로그아웃 시 isLoggedIn 값을 false로 설정하고 로컬 스토리지에서 제거
+      // set({ isLoggedIn: false });
+      // LocalStorage.removeItem('isLoggedIn');
+    },
+  };
+});
 
 export default useAuthStore;

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -1,0 +1,27 @@
+class LocalStorage {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor, @typescript-eslint/no-empty-function
+  constructor() {}
+
+  static setItem(key: string, value: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(key, value);
+    }
+  }
+
+  // getItem 은 return 을 넣어줘야함! setItem, removeItem이랑 다르게 값을 보여주는녀석!
+  static getItem(key: string) {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem(key);
+    }
+    // window객체 localStorage, sessionStorage는 값이 없을때 null
+    return null;
+  }
+
+  static removeItem(key: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+export default LocalStorage;


### PR DESCRIPTION
## 📝#52 작업 내용

> accessToken을 현재 로컬스토리지에 저장 완료하고 axiosInstance, useAuthStore 업데이트 했습니다.

- [x] 토큰 저장
- [x] 상태 업데이트
- [x] localStorage util화

## 💬 리뷰 요구사항
> 전역변수와 로컬스토리지 두 곳에 모두 accessToken 저장하는 부분은 추후에 한 곳을 뺄 수도 있을 것 같습니다.
> 개발 완료가 아니라 현재 언급한 문제들이 있는데 업데이트 되는대로 수정하겠습니다! 문제 있으면 말씀해주세요!

 ## 특이사항
- 백엔드 refresh api 요청이 지금 안되서 1시간이 지나면 콘솔에 401이 찍힙니다.
- 로그아웃 처리 부분 아직 api 개발 완료가 안되서 임시 주석 처리 해놨습니다.
- hydration 오류로 헤더 아이콘 조건부렌더링 임시 주석처리하고 헤더에 mypage, login 아이콘 일단 두 개 다 넣어놨습니다.
-> isLoggedIn 상태를 localStorage에 저장해놨는데 이 문제로 변경될 수 있습니다.
- 'use client'가 아닌 환경에서  localStorage을 사용하려면 utils에서 LocalStorage 불러와 사용해주세요.