### PR TITLE
#60 refactor: accessToken 저장 위치 수정, 새로고침시마다 토큰 업데이트

### DIFF
--- a/src/app/(auth)/login/email/page.tsx
+++ b/src/app/(auth)/login/email/page.tsx
@@ -6,6 +6,8 @@ import { validateEmail, validatePassword } from '@/utils/validations';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import useAuthStore from '@/store/authStore';
+import axiosInstance from '@/app/api/axiosInstance';
+import { AxiosError } from 'axios';
 import { EyeSlashFilledIcon } from './EyeSlashFilledIcon';
 import { EyeFilledIcon } from './EyeFilledIcon';
 
@@ -14,7 +16,7 @@ const EmailLogin = () => {
   const [isVisible, setIsVisible] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { login } = useAuthStore();
+  const { setAccessToken } = useAuthStore();
 
   const isEmailInvalid = useMemo(
     () => !validateEmail(email) && email !== '',
@@ -32,15 +34,34 @@ const EmailLogin = () => {
     }
 
     try {
-      await login(email, password);
+      const response = await axiosInstance.post('/api/login', {
+        email,
+        password,
+      });
 
-      alert('로그인 성공!');
-      router.push('/');
+      console.log(response);
+
+      if (response.status === 200) {
+        const { accessToken } = response.data;
+        setAccessToken(accessToken);
+
+        alert('로그인 성공!');
+        router.back();
+      }
     } catch (error) {
-      console.error('로그인 실패:', error);
+      console.log('로그인 실패:', error);
+      if (error instanceof AxiosError) {
+        const message =
+          error.response?.data?.message ||
+          '죄송합니다. 로그인에 실패했습니다. 서버 오류 발생.';
+        alert(message);
+      } else {
+        alert('죄송합니다. 알 수 없는 오류가 발생했습니다.');
+      }
     }
   };
   const toggleVisibility = () => setIsVisible(!isVisible);
+
   return (
     <div className="mt-14 flex h-full w-full flex-col flex-wrap justify-center gap-3 p-5 align-middle md:flex-nowrap">
       <h1 className="mb-4 text-2xl font-bold sm:text-xl">

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -70,6 +70,7 @@ const SignUp = () => {
           '죄송합니다. 회원가입에 실패했습니다. 서버 오류 발생.';
         alert(message);
       } else {
+        console.log(error);
         alert('죄송합니다. 알 수 없는 오류가 발생했습니다.');
       }
     }

--- a/src/app/api/auth.ts
+++ b/src/app/api/auth.ts
@@ -11,6 +11,6 @@ export const fetchAccessToken = async (
       axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
     }
   } catch (error) {
-    // console.log('Failed to fetch access token:', error);
+    console.log('Failed to fetch access token:', error);
   }
 };

--- a/src/app/api/auth.ts
+++ b/src/app/api/auth.ts
@@ -1,15 +1,9 @@
 import axiosInstance from './axiosInstance';
 
 export const fetchAccessToken = async (
-  setAccessToken: (accessToken: string | null) => void,
-  setIsRefreshing: (isRefreshing: boolean) => void
+  setAccessToken: (accessToken: string | null) => void
 ) => {
-  if (!setIsRefreshing) {
-    return;
-  }
-
   try {
-    setIsRefreshing(true);
     const response = await axiosInstance.patch('/api/tokens/refresh');
     if (response.status === 200) {
       const newAccessToken = response.headers.authorization;
@@ -18,7 +12,5 @@ export const fetchAccessToken = async (
     }
   } catch (error) {
     // console.log('Failed to fetch access token:', error);
-  } finally {
-    setIsRefreshing(false);
   }
 };

--- a/src/app/api/auth.ts
+++ b/src/app/api/auth.ts
@@ -1,0 +1,24 @@
+import axiosInstance from './axiosInstance';
+
+export const fetchAccessToken = async (
+  setAccessToken: (accessToken: string | null) => void,
+  setIsRefreshing: (isRefreshing: boolean) => void
+) => {
+  if (!setIsRefreshing) {
+    return;
+  }
+
+  try {
+    setIsRefreshing(true);
+    const response = await axiosInstance.patch('/api/tokens/refresh');
+    if (response.status === 200) {
+      const newAccessToken = response.headers.authorization;
+      setAccessToken(newAccessToken);
+      axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+    }
+  } catch (error) {
+    // console.log('Failed to fetch access token:', error);
+  } finally {
+    setIsRefreshing(false);
+  }
+};

--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
-import LocalStorage from '@/utils/localstorage';
+import axios, { AxiosError } from 'axios';
+import { useRouter } from 'next/navigation';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -8,31 +8,77 @@ const axiosInstance = axios.create({
   timeout: 10000,
 });
 
-export const storeAccessToken = (accessToken: string) => {
-  if (accessToken) {
-    LocalStorage.setItem('slam', accessToken);
-  }
-};
+let accessToken: string | null = null;
 
-axiosInstance.interceptors.request.use(async (config) => {
-  const accessToken = LocalStorage.getItem('slam');
-
-  if (accessToken) {
-    // eslint-disable-next-line no-param-reassign
-    config.headers.Authorization = `Bearer ${accessToken}`;
-  }
-  return config;
-});
-
-axiosInstance.interceptors.response.use(
-  async (response) => {
-    if (response?.data?.results) {
-      const { accessToken } = response.data.results;
-      storeAccessToken(accessToken);
+axiosInstance.interceptors.request.use(
+  (config) => {
+    if (accessToken) {
+      // eslint-disable-next-line no-param-reassign
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
-    return response;
+    return config;
   },
   (error) => Promise.reject(error)
+);
+
+let isRefreshing = false;
+let failedRequests: (() => void)[] = [];
+
+const processFailedRequests = (token?: string) => {
+  failedRequests.forEach((callback) => {
+    if (token) {
+      callback();
+    }
+  });
+  failedRequests = [];
+};
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest.retryFlag) {
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          failedRequests.push(() => {
+            originalRequest.retryFlag = true;
+            resolve(axiosInstance(originalRequest));
+          });
+        });
+      }
+      isRefreshing = true;
+      originalRequest.retryFlag = true;
+
+      try {
+        const refreshResponse = await axiosInstance.patch(
+          '/api/tokens/refresh',
+          {}
+        );
+        const newAccessToken = refreshResponse.data.accessToken;
+
+        accessToken = newAccessToken;
+
+        processFailedRequests(newAccessToken);
+
+        return await axiosInstance(originalRequest);
+      } catch (refreshError) {
+        if (
+          refreshError instanceof AxiosError &&
+          refreshError.response?.status === 401
+        ) {
+          console.log('토큰 재발급 실패');
+          processFailedRequests();
+          // logout 넣기
+          const router = useRouter();
+          router.push('/login');
+        }
+        return await Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+    return Promise.reject(error);
+  }
 );
 
 export default axiosInstance;

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,22 +1,22 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import Link from 'next/link';
 import { Anton } from 'next/font/google';
 import { PiBell, PiUserCircle } from 'react-icons/pi';
 import { LuLogIn } from 'react-icons/lu';
+import useAuthStore from '@/store/authStore';
 import { fetchAccessToken } from '../api/auth';
 
 // Anton 폰트 설정
 const anton = Anton({ weight: '400', subsets: ['latin'] });
 
 const Header = () => {
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-  const [, setIsRefreshing] = useState(false); // 동시다발적인 요청 방지
+  const { accessToken, setAccessToken } = useAuthStore();
 
   useEffect(() => {
-    fetchAccessToken(setAccessToken, setIsRefreshing);
-  }, [accessToken]);
+    fetchAccessToken(setAccessToken);
+  }, [setAccessToken]);
 
   return (
     <div className="fixed z-30 flex h-[61px] w-full max-w-[600px] items-center justify-between border-b-1 bg-background pl-4">

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,31 +1,32 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Anton } from 'next/font/google';
 import { PiBell, PiUserCircle } from 'react-icons/pi';
 import { LuLogIn } from 'react-icons/lu';
-// import useAuthStore from '@/store/authStore';
+import { fetchAccessToken } from '../api/auth';
 
+// Anton 폰트 설정
 const anton = Anton({ weight: '400', subsets: ['latin'] });
 
-const Header = () => (
-  // const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+const Header = () => {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [, setIsRefreshing] = useState(false); // 동시다발적인 요청 방지
 
-  <div className="fixed z-30 flex h-[61px] w-full max-w-[600px] items-center justify-between border-b-1 bg-background pl-4">
-    <div className={`${anton.className} text-2xl`}>
-      <Link href="/">
-        <div>SLAM TALK</div>
-      </Link>
-    </div>
-    <div className="flex space-x-4 pr-4">
-      <Link href="/mypage">
-        <PiUserCircle aria-label="알림" size={25} />
-      </Link>
-      <Link href="/login">
-        <LuLogIn aria-label="로그인" size={24} />
-      </Link>
-      {/* {isLoggedIn ? (
+  useEffect(() => {
+    fetchAccessToken(setAccessToken, setIsRefreshing);
+  }, [accessToken]);
+
+  return (
+    <div className="fixed z-30 flex h-[61px] w-full max-w-[600px] items-center justify-between border-b-1 bg-background pl-4">
+      <div className={`${anton.className} text-2xl`}>
+        <Link href="/">
+          <div>SLAM TALK</div>
+        </Link>
+      </div>
+      <div className="flex space-x-4 pr-4">
+        {accessToken ? (
           <Link href="/mypage">
             <PiUserCircle aria-label="알림" size={25} />
           </Link>
@@ -33,9 +34,11 @@ const Header = () => (
           <Link href="/login">
             <LuLogIn aria-label="로그인" size={24} />
           </Link>
-        )} */}
-      <PiBell size={24} />
+        )}
+        <PiBell size={24} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
+
 export default Header;

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -16,7 +16,8 @@ const Header = () => {
 
   useEffect(() => {
     fetchAccessToken(setAccessToken);
-  }, [setAccessToken]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="fixed z-30 flex h-[61px] w-full max-w-[600px] items-center justify-between border-b-1 bg-background pl-4">

--- a/src/app/map/KakaoMap.tsx
+++ b/src/app/map/KakaoMap.tsx
@@ -8,7 +8,6 @@ import { BiSolidLocationPlus } from 'react-icons/bi';
 import CourtReport from './CourtReport';
 import CourtDetails from './CourtDetail';
 import axiosInstance from '../api/axiosInstance';
-import { fetchAccessToken } from '../api/auth';
 
 declare global {
   interface Window {
@@ -26,13 +25,10 @@ const KakaoMap: FC = () => {
   const [mapLevel] = useState(3);
   const [isCourtReportVisible, setIsCourtReportVisible] = useState(false);
   const [isCourtDetailsVisible, setIsCourtDetailsVisible] = useState(false);
-  const [, setAccessToken] = useState<string | null>(null);
 
   // 백엔드 API로부터 농구장 정보 가져오기
   const fetchBasketballCourts = async () => {
     try {
-      await fetchAccessToken(setAccessToken);
-
       const response = await axiosInstance.get('/api/map');
 
       if (response.status === 200) {

--- a/src/app/map/KakaoMap.tsx
+++ b/src/app/map/KakaoMap.tsx
@@ -7,6 +7,8 @@ import { MdMyLocation } from 'react-icons/md';
 import { BiSolidLocationPlus } from 'react-icons/bi';
 import CourtReport from './CourtReport';
 import CourtDetails from './CourtDetail';
+import axiosInstance from '../api/axiosInstance';
+import { fetchAccessToken } from '../api/auth';
 
 declare global {
   interface Window {
@@ -24,6 +26,28 @@ const KakaoMap: FC = () => {
   const [mapLevel] = useState(3);
   const [isCourtReportVisible, setIsCourtReportVisible] = useState(false);
   const [isCourtDetailsVisible, setIsCourtDetailsVisible] = useState(false);
+  // Define state variables for access token and refreshing flag
+  const [, setAccessToken] = useState<string | null>(null);
+  const [, setIsRefreshing] = useState<boolean>(false);
+
+  // 백엔드 API로부터 농구장 정보 가져오기
+  const fetchBasketballCourts = async () => {
+    try {
+      await fetchAccessToken(setAccessToken, setIsRefreshing);
+
+      const response = await axiosInstance.get('/api/map');
+
+      if (response.status === 200) {
+        // 성공적으로 데이터를 가져왔을 경우
+        console.log(response);
+        const courtData = response.data;
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        displayBasketballCourts(courtData);
+      }
+    } catch (error) {
+      console.error('농구장 정보를 불러오는데 실패했습니다:', error);
+    }
+  };
 
   useEffect(() => {
     if (!window.kakao || !window.kakao.maps) {
@@ -47,6 +71,8 @@ const KakaoMap: FC = () => {
           const kakaoMap = new window.kakao.maps.Map(mapRef.current, options);
           setMap(kakaoMap);
           setIsLoading(false);
+
+          fetchBasketballCourts();
         },
         (error) => {
           console.error(`Error: ${error.message}`);
@@ -61,6 +87,7 @@ const KakaoMap: FC = () => {
         }
       );
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapLevel]);
 
   const moveToLocation = () => {
@@ -89,7 +116,7 @@ const KakaoMap: FC = () => {
         (data: any, status: any) => {
           if (status === window.kakao.maps.services.Status.OK) {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            displayPlaces(data);
+            displayBasketballCourts(data);
           } else if (status === window.kakao.maps.services.Status.ZERO_RESULT) {
             alert('검색 결과가 존재하지 않습니다.');
           } else if (status === window.kakao.maps.services.Status.ERROR) {
@@ -101,7 +128,7 @@ const KakaoMap: FC = () => {
     }
   };
 
-  const displayPlaces = (places: any) => {
+  const displayBasketballCourts = (courts: any) => {
     if (!map) return;
 
     const bounds = new window.kakao.maps.LatLngBounds();
@@ -112,34 +139,75 @@ const KakaoMap: FC = () => {
       imageSize
     );
 
-    places.forEach((place: any) => {
+    courts.forEach((court: any) => {
+      const { latitude, longitude, name } = court;
       const marker = new window.kakao.maps.Marker({
         map,
-        position: new window.kakao.maps.LatLng(place.y, place.x),
+        position: new window.kakao.maps.LatLng(latitude, longitude),
         image: markerImage,
       });
 
-      const content = `<div class="flex items-center px-2 py-1 bg-white text-black border border-gray-300 rounded text-sm font-medium shadow-sm ml-12">${place.place_name}</div>`;
+      const content = `<div class="flex items-center px-2 py-1 bg-white text-black border border-gray-300 rounded text-sm font-medium shadow-sm ml-12">${name}</div>`;
 
       // eslint-disable-next-line no-new
       new window.kakao.maps.CustomOverlay({
         map,
-        position: new window.kakao.maps.LatLng(place.y, place.x),
+        position: new window.kakao.maps.LatLng(latitude, longitude),
         content,
         yAnchor: 1,
         xAnchor: 0.5,
       });
 
       window.kakao.maps.event.addListener(marker, 'click', () => {
-        setSelectedPlace(place);
+        setSelectedPlace(court);
         setIsCourtDetailsVisible(true);
       });
 
-      bounds.extend(new window.kakao.maps.LatLng(place.y, place.x));
+      bounds.extend(new window.kakao.maps.LatLng(latitude, longitude));
     });
 
     map.setBounds(bounds);
   };
+
+  // const displayPlaces = (places: any) => {
+  //   if (!map) return;
+
+  //   const bounds = new window.kakao.maps.LatLngBounds();
+  //   const markerImageSrc = '/icons/marker-img.png';
+  //   const imageSize = new window.kakao.maps.Size(48);
+  //   const markerImage = new window.kakao.maps.MarkerImage(
+  //     markerImageSrc,
+  //     imageSize
+  //   );
+
+  //   places.forEach((place: any) => {
+  //     const marker = new window.kakao.maps.Marker({
+  //       map,
+  //       position: new window.kakao.maps.LatLng(place.y, place.x),
+  //       image: markerImage,
+  //     });
+
+  //     const content = `<div class="flex items-center px-2 py-1 bg-white text-black border border-gray-300 rounded text-sm font-medium shadow-sm ml-12">${place.place_name}</div>`;
+
+  //     // eslint-disable-next-line no-new
+  //     new window.kakao.maps.CustomOverlay({
+  //       map,
+  //       position: new window.kakao.maps.LatLng(place.y, place.x),
+  //       content,
+  //       yAnchor: 1,
+  //       xAnchor: 0.5,
+  //     });
+
+  //     window.kakao.maps.event.addListener(marker, 'click', () => {
+  //       setSelectedPlace(place);
+  //       setIsCourtDetailsVisible(true);
+  //     });
+
+  //     bounds.extend(new window.kakao.maps.LatLng(place.y, place.x));
+  //   });
+
+  //   map.setBounds(bounds);
+  // };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -154,6 +222,21 @@ const KakaoMap: FC = () => {
   const hideCourtReport = () => {
     setIsCourtReportVisible(false);
   };
+
+  // const showCourtDetails = () => {
+  //   setIsCourtDetailsVisible(true);
+  // };
+
+  // const closeCourtDetails = () => {
+  //   setIsCourtDetailsVisible(false);
+  // };
+
+  // useEffect(() => {
+  //   // Initialize the map and fetch basketball court data
+  //   if (!map) return;
+
+  //   fetchBasketballCourts();
+  // }, [map]);
 
   return (
     <div className="relative h-full w-full">

--- a/src/app/map/KakaoMap.tsx
+++ b/src/app/map/KakaoMap.tsx
@@ -26,14 +26,12 @@ const KakaoMap: FC = () => {
   const [mapLevel] = useState(3);
   const [isCourtReportVisible, setIsCourtReportVisible] = useState(false);
   const [isCourtDetailsVisible, setIsCourtDetailsVisible] = useState(false);
-  // Define state variables for access token and refreshing flag
   const [, setAccessToken] = useState<string | null>(null);
-  const [, setIsRefreshing] = useState<boolean>(false);
 
   // 백엔드 API로부터 농구장 정보 가져오기
   const fetchBasketballCourts = async () => {
     try {
-      await fetchAccessToken(setAccessToken, setIsRefreshing);
+      await fetchAccessToken(setAccessToken);
 
       const response = await axiosInstance.get('/api/map');
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,32 +1,18 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { NextUIProvider } from '@nextui-org/react';
 import { ThemeProvider } from 'next-themes';
-import useAuthStore from '@/store/authStore';
 
-const Providers = ({ children }: { children: React.ReactNode }) => {
-  const { setAccessToken } = useAuthStore();
-
-  useEffect(() => {
-    // 페이지 로딩 시 토큰을 가져와서 로그인 상태를 설정
-    const accessToken = localStorage.getItem('slam');
-    if (accessToken) {
-      setAccessToken(accessToken);
-    }
-  }, [setAccessToken]); // setAccessToken을 의존성으로 추가하여 변화할 때마다 호출
-
-  return (
-    <NextUIProvider>
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="dark"
-        themes={['light', 'dark']}
-      >
-        {children}
-      </ThemeProvider>
-    </NextUIProvider>
-  );
-};
-
+const Providers = ({ children }: { children: React.ReactNode }) => (
+  <NextUIProvider>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="dark"
+      themes={['light', 'dark']}
+    >
+      {children}
+    </ThemeProvider>
+  </NextUIProvider>
+);
 export default Providers;

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,66 +1,13 @@
 import { create } from 'zustand';
-import LocalStorage from '@/utils/localstorage';
-import axiosInstance, { storeAccessToken } from '@/app/api/axiosInstance';
 
 interface AuthState {
   accessToken: string | null;
-  isLoggedIn: boolean;
   setAccessToken: (token: string | null) => void;
-  login: (email: string, password: string) => void;
-  logout: () => void;
 }
 
-const useAuthStore = create<AuthState>((set) => {
-  // isLoggedIn 값을 LocalStorage에서 가져와서 명시적으로 boolean으로 변환
-  const isLoggedIn = LocalStorage.getItem('isLoggedIn') === 'true';
-
-  return {
-    accessToken: LocalStorage.getItem('slam') || null,
-    isLoggedIn,
-    setAccessToken: (token) => {
-      if (token) {
-        LocalStorage.setItem('slam', token);
-        set({ accessToken: token, isLoggedIn: true });
-        // isLoggedIn 값을 로컬 스토리지에 저장
-        LocalStorage.setItem('isLoggedIn', 'true');
-      } else {
-        LocalStorage.removeItem('slam');
-        set({ accessToken: null, isLoggedIn: false });
-        // isLoggedIn 값을 로컬 스토리지에서 제거
-        LocalStorage.removeItem('isLoggedIn');
-      }
-    },
-    login: async (email, password) => {
-      try {
-        const response = await axiosInstance.post('/api/login', {
-          email,
-          password,
-        });
-
-        if (response.status === 200) {
-          const { accessToken } = response.data;
-
-          // 로그인 성공 시 토큰을 저장하고 상태를 업데이트
-          storeAccessToken(accessToken);
-          set({ accessToken, isLoggedIn: true });
-
-          // isLoggedIn 값을 로컬 스토리지에 저장
-          LocalStorage.setItem('isLoggedIn', 'true');
-        }
-      } catch (error) {
-        // 에러 처리 로직
-        console.error('로그인 실패:', error);
-        throw error;
-      }
-    },
-    logout: () => {
-      // 로그아웃 처리 로직 추가
-      // 예: 로그아웃 API 호출 후 setAccessToken 호출
-      // 로그아웃 시 isLoggedIn 값을 false로 설정하고 로컬 스토리지에서 제거
-      // set({ isLoggedIn: false });
-      // LocalStorage.removeItem('isLoggedIn');
-    },
-  };
-});
+const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  setAccessToken: (token) => set({ accessToken: token }),
+}));
 
 export default useAuthStore;


### PR DESCRIPTION
## 📝#60 작업 내용

> 멘토링 사항을 반영해 accessToken 저장 위치를 localStorage에서 메모리(변수로) 바꾸고 이에 따라 새로고침시 'api/tokens/refresh' patch 요청을 보내는 로직으로 수정 완료 했습니다.

- [x] zustand, axiosInstance 설정 변경하기
- [x] accessToken localStorage가 아니라 메모리(변수)에 저장으로 수정

## 💬 리뷰 요구사항
- 👀 같이 리뷰 필요
  > axiosInstance.interceptors.request.use: 요청 인터셉터 - 모든 요청 전에 실행되는 요청 인터셉터 설정
  > axiosInstance.interceptors.response.use: 응답 인터셉터 - 모든 응답을 처리하는 응답 인터셉터 설정
  > originalRequest 변수에 현재 요청 정보를 저장
  > processFailedRequests 함수: 이전에 실패한 요청들을 다시 처리하기 위해 실패한 요청 콜백들을 호출하는 역할
  >   - 토큰 갱신 성공시: 새로운 토큰으로 이전 실패한 요청들을 다시 시도.
  >  - 토큰 갱신 실패시: 갱신 실패시 로그아웃 시키고 /login 페이지로 리다이렉트하는 것이 일반적. 그 전에 실패한 요청들을 처리하기 위해 이 함수를 호출하여 이전 요청 콜백들을 실행한다.
  > isRefreshing와 failedRequests 변수
  >  - isRefreshing 변수는 토큰 재발급 중인지를 나타내는 boolean 값.
  >  - failedRequests 배열은 토큰 재발급 중에 실패한 모든 요청을 저장.
  > 다른 axiosInstance 요청 전 refresh로 제대로 accessToken을 가져온 후 요청을 보내기 위해 setIsRefreshing 사용
  > accessToken 가져오는 로직 fetchAccessToken 함수 auth.ts 파일로 분리

## 특이사항
- 로그아웃 로직 추가 예정입니다.

resolved: #60 