### PR TITLE
#56 소셜 로그인 연결 - 카카오

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import { Anton } from 'next/font/google';
 import { Button } from '@nextui-org/button';
 import Link from 'next/link';
@@ -10,61 +11,78 @@ import NaverImg from './Naver';
 
 const anton = Anton({ weight: '400', subsets: ['latin'] });
 
-const Login = () => (
-  <div className="flex w-full flex-col items-center justify-center text-center">
-    <div className={`${anton.className} my-32 text-6xl sm:my-20`}>
-      SLAM TALK
-    </div>
-    <div className="flex flex-col gap-4 font-semibold">
-      <Link href="/login/kakao">
+const Login = () => {
+  const router = useRouter();
+  const handleKakaoLogin = () => {
+    const kakaoLoginURL = `${process.env.NEXT_PUBLIC_BASE_URL}/oauth2/authorization/kakao`;
+    router.push(kakaoLoginURL);
+  };
+  const handleNaverLogin = () => {
+    const naverLoginURL = `${process.env.NEXT_PUBLIC_BASE_URL}/oauth2/authorization/naver`;
+    router.push(naverLoginURL);
+  };
+  const handleGoogleLogin = () => {
+    const googleLoginURL = `${process.env.NEXT_PUBLIC_BASE_URL}/oauth2/authorization/google`;
+    router.push(googleLoginURL);
+  };
+
+  return (
+    <div className="flex w-full flex-col items-center justify-center text-center">
+      <div className={`${anton.className} my-32 text-6xl sm:my-20`}>
+        SLAM TALK
+      </div>
+      <div className="flex flex-col gap-4 font-semibold">
         <Button
           size="lg"
           radius="full"
           className="relative w-full min-w-80 bg-kakao font-semibold text-black shadow-md dark:shadow-slate-500 md:w-96"
+          onClick={handleKakaoLogin}
         >
           <div className="absolute left-6">
             <KakaoImg />
           </div>
           <span className="ml-3">카카오로 3초 만에 로그인하기</span>
         </Button>
-      </Link>
-      <Link href="/login/naver">
-        <Button
-          size="lg"
-          radius="full"
-          className="relative w-full min-w-80 bg-naver font-semibold text-white shadow-md dark:shadow-slate-500 md:w-96"
-        >
-          <div className="absolute left-4">
-            <NaverImg />
-          </div>
-          <span className="ml-3">네이버로 계속하기</span>
-        </Button>
-      </Link>
-      <Link href="/login/google">
-        <Button
-          size="lg"
-          radius="full"
-          className="relative mb-2.5 w-full min-w-80 border-1 border-gray-400 bg-white font-semibold text-black shadow-md dark:shadow-slate-500 md:w-96"
-        >
-          <div className="absolute left-6">
-            <GoogleImg />
-          </div>
-          <span className="ml-3">구글로 계속하기</span>
-        </Button>
-      </Link>
+        <Link href="/login/naver">
+          <Button
+            size="lg"
+            radius="full"
+            className="relative w-full min-w-80 bg-naver font-semibold text-white shadow-md dark:shadow-slate-500 md:w-96"
+            onClick={handleNaverLogin}
+          >
+            <div className="absolute left-4">
+              <NaverImg />
+            </div>
+            <span className="ml-3">네이버로 계속하기</span>
+          </Button>
+        </Link>
+        <Link href="/login/google">
+          <Button
+            size="lg"
+            radius="full"
+            className="relative mb-2.5 w-full min-w-80 border-1 border-gray-400 bg-white font-semibold text-black shadow-md dark:shadow-slate-500 md:w-96"
+            onClick={handleGoogleLogin}
+          >
+            <div className="absolute left-6">
+              <GoogleImg />
+            </div>
+            <span className="ml-3">구글로 계속하기</span>
+          </Button>
+        </Link>
+      </div>
+      <div>
+        <hr className="mt-4 h-px w-80 bg-gray-400 sm:w-72" />
+      </div>
+      <div className="mt-5 flex gap-3 align-middle text-sm text-gray-500 dark:text-gray-300">
+        <Link href="/signup">
+          <p>이메일로 가입</p>
+        </Link>
+        <hr className="h-4 w-px bg-gray-300" />
+        <Link href="/login/email">
+          <p>이메일 로그인</p>
+        </Link>
+      </div>
     </div>
-    <div>
-      <hr className="mt-4 h-px w-80 bg-gray-400 sm:w-72" />
-    </div>
-    <div className="mt-5 flex gap-3 align-middle text-sm text-gray-500 dark:text-gray-300">
-      <Link href="/signup">
-        <p>이메일로 가입</p>
-      </Link>
-      <hr className="h-4 w-px bg-gray-300" />
-      <Link href="/login/email">
-        <p>이메일 로그인</p>
-      </Link>
-    </div>
-  </div>
-);
+  );
+};
 export default Login;

--- a/src/app/api/auth.ts
+++ b/src/app/api/auth.ts
@@ -2,6 +2,7 @@ import axiosInstance from './axiosInstance';
 
 export const fetchAccessToken = async (
   setAccessToken: (accessToken: string | null) => void
+  // eslint-disable-next-line consistent-return
 ) => {
   try {
     const response = await axiosInstance.patch('/api/tokens/refresh');
@@ -9,6 +10,7 @@ export const fetchAccessToken = async (
       const newAccessToken = response.headers.authorization;
       setAccessToken(newAccessToken);
       axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+      return response;
     }
   } catch (error) {
     console.log('Failed to fetch access token:', error);

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -16,8 +16,8 @@ const Header = () => {
   const { accessToken, setAccessToken } = useAuthStore();
   const router = useRouter();
 
-  useEffect(() => {
-    const fetchData = async () => {
+  const handleAccessTokenFetch = async () => {
+    try {
       const response = await fetchAccessToken(setAccessToken);
       if (response && response.data && response.data.results) {
         const { firstLoginCheck } = response.data.results;
@@ -25,9 +25,13 @@ const Header = () => {
           router.push('/user-info');
         }
       }
-    };
+    } catch (error) {
+      console.error('Failed to fetch access token:', error);
+    }
+  };
 
-    fetchData();
+  useEffect(() => {
+    handleAccessTokenFetch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -6,6 +6,7 @@ import { Anton } from 'next/font/google';
 import { PiBell, PiUserCircle } from 'react-icons/pi';
 import { LuLogIn } from 'react-icons/lu';
 import useAuthStore from '@/store/authStore';
+import { useRouter } from 'next/navigation';
 import { fetchAccessToken } from '../api/auth';
 
 // Anton 폰트 설정
@@ -13,9 +14,20 @@ const anton = Anton({ weight: '400', subsets: ['latin'] });
 
 const Header = () => {
   const { accessToken, setAccessToken } = useAuthStore();
+  const router = useRouter();
 
   useEffect(() => {
-    fetchAccessToken(setAccessToken);
+    const fetchData = async () => {
+      const response = await fetchAccessToken(setAccessToken);
+      if (response && response.data && response.data.results) {
+        const { firstLoginCheck } = response.data.results;
+        if (firstLoginCheck === true) {
+          router.push('/user-info');
+        }
+      }
+    };
+
+    fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## 📝 #56 작업 내용

> 카카오 소셜 로그인 연결 완료.

- [x] 카카오 소셜 로그인 연결
- [x] 첫 회원가입시(즉, firstLoginCheck === true이면) '/user-info'로 이동

## 💬 리뷰 요구사항
- 👀 같이 리뷰 필요
  > 현재 백엔드단에서 카카오 소셜 로그인을 완료하면 '/login-success' 페이지로 이동시켜주는데 이 부분 firstLoginCheck 정보를 헤더에서 매 새로고침마다 받고 있어서 '/login-success'가 없어도 될 것 같습니다.
  > 원래는 '/login-success' 페이지에서 axiosInstance /refresh 요청을 해 응답에서 firstLoginCheck 정보을 체크하려고 '/login-success'를 만들었는데 전체 토큰 로직이 매 새로고침받아 받아지는 로직으로 바뀌어 수정 필요해보입니다.

## 특이사항
- naver, google 소셜 로그인은 현재 개발 완료 전입니다.
- 처음 소셜 회원가입 테스트를 같이 해보면 좋을 것 같습니다!
