### PR TITLE
#120 회원가입시 이메일 인증

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -20,6 +20,7 @@ const SignUp = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [nicknameTouched, setNicknameTouched] = useState(false);
+  const [code, setCode] = useState('');
 
   const isNicknameInvalid = useMemo(
     () =>
@@ -84,6 +85,47 @@ const SignUp = () => {
     if (!nicknameTouched) setNicknameTouched(true);
   };
 
+  const handleSendEmailCode = async () => {
+    if (!email) {
+      alert('이메일을 입력해주세요.');
+      return;
+    }
+    try {
+      const response = await axiosInstance.post('/api/send-mail', {
+        email,
+      });
+      if (response.status === 200) {
+        alert(
+          '이메일 인증 요청을 보냈습니다. 5분 안에 인증코드를 입력해주세요.'
+        );
+      }
+    } catch (error) {
+      alert('이메일 인증 요청에 실패했습니다.');
+    }
+  };
+
+  const handleValidateEmailCode = async () => {
+    if (!email) {
+      alert('이메일을 입력해주세요.');
+      return;
+    }
+    if (!code) {
+      alert('인증 코드를 입력해주세요.');
+      return;
+    }
+    try {
+      const response = await axiosInstance.get(
+        `/api/mail-check?email=${email}&code=${code}`
+      );
+      if (response.status === 200) {
+        alert('이메일 인증에 성공했습니다!');
+      }
+    } catch (error) {
+      console.log('이메일 인증 실패:', error);
+      alert('이메일 인증에 실패했습니다.');
+    }
+  };
+
   return (
     <>
       <title>슬램톡 | 회원가입</title>
@@ -110,24 +152,57 @@ const SignUp = () => {
           {isNicknameInvalid &&
             '닉네임은 특수 문자 제외 2자 이상 13자 이하이어야 합니다.'}
         </div>
-        <Input
-          radius="sm"
-          isClearable
-          isRequired
-          type="email"
-          labelPlacement="outside"
-          label="이메일"
-          value={email}
-          onChange={handleemailChange}
-          onValueChange={setEmail}
-          onClear={() => console.log('input cleared')}
-          placeholder="로그인시 필요"
-          isInvalid={isEmailInvalid}
-        />
+        <div className="flex items-center gap-3">
+          <Input
+            radius="sm"
+            isClearable
+            isRequired
+            type="email"
+            labelPlacement="outside"
+            label="이메일"
+            value={email}
+            onChange={handleemailChange}
+            onValueChange={setEmail}
+            onClear={() => console.log('input cleared')}
+            placeholder="로그인시 필요"
+            isInvalid={isEmailInvalid}
+          />
+          <Button
+            type="submit"
+            variant="ghost"
+            radius="sm"
+            className="top-3 max-w-xs font-medium"
+            color="danger"
+            onClick={handleSendEmailCode}
+          >
+            이메일 인증 요청
+          </Button>
+        </div>
         <div
           className={`mb-3 h-3 text-sm text-danger ${isEmailInvalid ? 'visible' : 'invisible'}`}
         >
           {isEmailInvalid && '올바른 이메일을 입력해주세요.'}
+        </div>
+        <div className="mb-6 flex items-center justify-end gap-3">
+          <Input
+            radius="sm"
+            isRequired
+            isClearable
+            labelPlacement="outside"
+            label="인증코드"
+            placeholder="인증코드 입력"
+            onValueChange={setCode}
+          />
+          <Button
+            type="submit"
+            variant="ghost"
+            radius="sm"
+            className="top-3 max-w-xs font-medium"
+            color="danger"
+            onClick={handleValidateEmailCode}
+          >
+            확인
+          </Button>
         </div>
         <Input
           radius="sm"


### PR DESCRIPTION
## 📝 #120 작업 내용

> 회원가입시 이메일 인증 구현

- [x] 이메일 인증

### 스크린샷
<img width="50%" src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/cab59a48-26fe-4e02-972b-e68003340340"/>

## 💬 리뷰 요구사항
  > 이메일 인증 성공 후 5분 동안 유효합니다. (이후 인증 요청을 다시 해서 실패했을시 실패한 값으로 업데이트하는 부분은 추후 백엔드에서 고려해야 할 것 같습니다.)
  > 이메일 인증 실패 에러가 자세하지 않아서 하나의 alert로 띄워놨습니다.
  > 추후 이메일 내용 html 작성 예정
