### PR TITLE
#108 refactor: 농구장 제보 도로명 주소 반영, RadioGroup type string으로 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,8 +36,9 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         setUserLocation({ latitude, longitude });
         return getAddressFromCoords(latitude, longitude);
       })
-      .then((address) => {
-        setUserAddress(address);
+      .then(({ address, roadAddress }) => {
+        const finalAddress = roadAddress || address;
+        setUserAddress(finalAddress);
       })
       .catch((error) => {
         console.error(error.message);

--- a/src/app/map/components/CourtReport.tsx
+++ b/src/app/map/components/CourtReport.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-/* eslint-disable no-param-reassign */
 /* eslint-disable no-useless-escape */
 import React, { useState } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { ErrorMessage } from '@hookform/error-message';
 import {
   Textarea,
@@ -27,6 +26,7 @@ import {
   basketballCourtSize,
   basketballConvenience,
 } from '@/constants/courtReportData';
+import { BasketballCourtReport } from '@/types/basketballCourt/basketballCourtReport';
 import { CameraIcon } from './icons/CameraIcon';
 
 interface CourtReportProps {
@@ -36,32 +36,12 @@ interface CourtReportProps {
   onReportSuccess: () => void;
 }
 
-export interface CourtReportData {
-  file: File | null;
-  courtName: string;
-  address: string;
-  latitude: number;
-  longitude: number;
-  courtType: string | null;
-  indoorOutdoor: string | null;
-  courtSize: string | null;
-  hoopCount: number | null;
-  nightLighting: string | boolean | null;
-  openingHours: string | boolean | null;
-  fee: string | boolean | null;
-  parkingAvailable: string | boolean | null;
-  phoneNum: string | null;
-  website: string | null;
-  convenience: string | null;
-  additionalInfo: string | null;
-}
-
 // 농구장 사진(1MB) ✅
 // (마커 정보→ 위도, 경도, 주소) ✅
 // 농구장명(필수), 주소(필수), 코트 종류, 실내외(실내/야외), 코트사이즈, 골대수, ✅
 // 야간 조명, 개방시간(제한/24시), 사용료, 주차 가능, 기타 정보 ✅
 // 전화번호, 홈페이지(링크), 편의시설 ✅
-// (도로명 주소 반영)
+// (도로명 주소 반영) ✅
 
 const CourtReport: React.FC<CourtReportProps> = ({
   position,
@@ -70,47 +50,25 @@ const CourtReport: React.FC<CourtReportProps> = ({
   onReportSuccess,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [reportSuccess, setReportSuccess] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const {
+    control,
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<CourtReportData>();
-  const onSubmit: SubmitHandler<CourtReportData> = async (data) => {
+  } = useForm<BasketballCourtReport>();
+  const onSubmit: SubmitHandler<BasketballCourtReport> = async (data) => {
     const formData = new FormData();
 
     if (file) {
       formData.append('image', file);
     }
 
-    // 백엔드와 데이터 타입 맞추기
     if (data.convenience?.length === 0) {
+      // eslint-disable-next-line no-param-reassign
       data.convenience = '';
-    }
-
-    if (data.nightLighting === '있음') {
-      data.nightLighting = true;
-    } else if (data.nightLighting === '없음') {
-      data.nightLighting = false;
-    }
-
-    if (data.openingHours === '제한') {
-      data.openingHours = false;
-    } else if (data.openingHours === '24시') {
-      data.openingHours = true;
-    }
-
-    if (data.fee === '무료') {
-      data.fee = false;
-    } else if (data.fee === '유료') {
-      data.fee = true;
-    }
-
-    if (data.parkingAvailable === '가능') {
-      data.parkingAvailable = true;
-    } else if (data.parkingAvailable === '불가능') {
-      data.parkingAvailable = false;
     }
 
     const finalData = {
@@ -119,6 +77,8 @@ const CourtReport: React.FC<CourtReportProps> = ({
       latitude: position.lat,
       longitude: position.lng,
     };
+
+    console.log(finalData);
 
     formData.append(
       'data',
@@ -134,12 +94,13 @@ const CourtReport: React.FC<CourtReportProps> = ({
         },
       });
       if (response.status === 200) {
+        setReportSuccess(true);
         onOpen();
         onReportSuccess();
       }
     } catch (error) {
-      console.log('제보 실패: ', error);
-      alert('농구장 제보에 실패했습니다.');
+      setReportSuccess(false);
+      onOpen();
     }
   };
 
@@ -408,42 +369,89 @@ const CourtReport: React.FC<CourtReportProps> = ({
                 )}
               />
             </div>
-            <RadioGroup
-              className="text-sm font-semibold"
-              label="야간 조명"
-              orientation="horizontal"
-              {...register('nightLighting')}
-            >
-              <Radio value="있음">있음</Radio>
-              <Radio value="없음">없음</Radio>
-            </RadioGroup>
-            <RadioGroup
-              className="pt-6 text-sm font-semibold"
-              label="개방 시간"
-              orientation="horizontal"
-              {...register('openingHours')}
-            >
-              <Radio value="제한">제한</Radio>
-              <Radio value="24시">24시</Radio>
-            </RadioGroup>
-            <RadioGroup
-              className="pt-6 text-sm font-semibold"
-              label="사용료"
-              orientation="horizontal"
-              {...register('fee')}
-            >
-              <Radio value="무료">무료</Radio>
-              <Radio value="유료">유료</Radio>
-            </RadioGroup>
-            <RadioGroup
-              className="pt-6 text-sm font-semibold"
-              label="주차여부"
-              orientation="horizontal"
-              {...register('parkingAvailable')}
-            >
-              <Radio value="가능">가능</Radio>
-              <Radio value="불가능">불가능</Radio>
-            </RadioGroup>
+            <div className="flex flex-col gap-4">
+              <Controller
+                control={control}
+                name="indoorOutdoor"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup
+                    value={value || ''}
+                    onChange={(value) => onChange(value)}
+                    className="text-sm font-semibold"
+                    label="실내외"
+                    orientation="horizontal"
+                  >
+                    <Radio value="실내">실내</Radio>
+                    <Radio value="야외">야외</Radio>
+                  </RadioGroup>
+                )}
+              />
+              <Controller
+                control={control}
+                name="nightLighting"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup
+                    value={value || ''}
+                    onChange={(value) => onChange(value)}
+                    className="text-sm font-semibold"
+                    label="야간 조명"
+                    orientation="horizontal"
+                  >
+                    <Radio value="있음">있음</Radio>
+                    <Radio value="없음">없음</Radio>
+                  </RadioGroup>
+                )}
+              />
+              <Controller
+                control={control}
+                name="openingHours"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup
+                    value={value || ''}
+                    onChange={(value) => onChange(value)}
+                    className="text-sm font-semibold"
+                    label="개방 시간"
+                    orientation="horizontal"
+                  >
+                    <Radio value="제한">제한</Radio>
+                    <Radio value="24시">24시</Radio>
+                  </RadioGroup>
+                )}
+              />
+              <Controller
+                control={control}
+                name="fee"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup
+                    value={value || ''}
+                    onChange={(value) => onChange(value)}
+                    className="text-sm font-semibold"
+                    label="사용료"
+                    orientation="horizontal"
+                  >
+                    <Radio value="무료">무료</Radio>
+                    <Radio value="유료">유료</Radio>
+                  </RadioGroup>
+                )}
+              />
+              <Controller
+                control={control}
+                name="parkingAvailable"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup
+                    value={value || ''}
+                    onChange={(value) => onChange(value)}
+                    className="text-sm font-semibold"
+                    label="주차 여부"
+                    orientation="horizontal"
+                  >
+                    <Radio value="가능">가능</Radio>
+                    <Radio value="불가능">불가능</Radio>
+                  </RadioGroup>
+                )}
+              />
+            </div>
+
             <div className="mt-6 w-full">
               <Textarea
                 radius="sm"
@@ -472,15 +480,23 @@ const CourtReport: React.FC<CourtReportProps> = ({
           {() => (
             <>
               <ModalHeader className="flex flex-col gap-1">
-                농구장 제보 성공
+                농구장 제보
               </ModalHeader>
               <ModalBody>
-                <p>감사합니다! 농구장 제보가 완료되었습니다.</p>
-                <p>관리자 검토 후 빠른 시일 내에 농구장 정보 반영하겠습니다.</p>
+                {reportSuccess ? (
+                  <>
+                    <p>감사합니다! 농구장 제보가 완료되었습니다.</p>
+                    <p>
+                      관리자 검토 후 빠른 시일 내에 농구장 정보 반영하겠습니다.
+                    </p>
+                  </>
+                ) : (
+                  <p>농구장 제보에 실패했습니다. 잠시 후 다시 시도해주세요.</p>
+                )}
               </ModalBody>
               <ModalFooter>
-                <Button color="danger" variant="light" onPress={handleClose}>
-                  닫기
+                <Button color="primary" onPress={handleClose}>
+                  확인
                 </Button>
               </ModalFooter>
             </>

--- a/src/app/map/components/KakaoMap.tsx
+++ b/src/app/map/components/KakaoMap.tsx
@@ -41,7 +41,7 @@ import CourtReport from './CourtReport';
 // 농구장 상세정보 UI 수정 ✅
 // 제보 모달 UI 수정 - 제보하기 Btn Fix ✅
 // 컨트롤 커스텀
-// 모바일 환경 움직임 확인하기
+// 모바일 환경 움직임 확인하기 ✅
 
 export interface LatLng {
   getLat: () => number;
@@ -68,7 +68,7 @@ const KakaoMap = () => {
   const [selectedCourtId, setSelectedCourtId] = useState<number>(1);
   const [mode, setMode] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState<string>('');
-  const [, setCoord] = useState('');
+  const [coord, setCoord] = useState('');
   const [position, setPosition] = useState<{
     lat: number;
     lng: number;
@@ -182,14 +182,21 @@ const KakaoMap = () => {
     setCoord(
       `클릭한 위치의 위도는 ${latlng.getLat()} 이고, 경도는 ${latlng.getLng()} 입니다`
     );
+    console.log(coord);
     if (mode === true) {
       setPosition({
         lat,
         lng,
       });
-      getAddressFromCoords(lat, lng).then((address) => {
-        setClickPositionAddress(address);
-      });
+      getAddressFromCoords(lat, lng)
+        .then(({ address, roadAddress }) => {
+          // 도로명 주소가 있으면 그 값을, 없으면 지번 주소를 사용
+          const finalAddress = roadAddress || address;
+          setClickPositionAddress(finalAddress);
+        })
+        .catch((error) => {
+          console.error('주소 정보를 가져오는데 실패했습니다.', error);
+        });
     }
   };
 

--- a/src/types/basketballCourt/basketballCourtReport.ts
+++ b/src/types/basketballCourt/basketballCourtReport.ts
@@ -1,0 +1,19 @@
+export interface BasketballCourtReport {
+  file: File | null;
+  courtName: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  courtType: string | null;
+  indoorOutdoor: string | null;
+  courtSize: string | null;
+  hoopCount: number | null;
+  nightLighting: string | null;
+  openingHours: string | null;
+  fee: string | null;
+  parkingAvailable: string | null;
+  phoneNum: string | null;
+  website: string | null;
+  convenience: string | null;
+  additionalInfo: string | null;
+}

--- a/src/utils/getUserLocation.ts
+++ b/src/utils/getUserLocation.ts
@@ -1,5 +1,14 @@
 import { Coords } from '@/types/location/userLocationType';
 
+interface AddressResult {
+  address: {
+    address_name: string; // 지번 주소
+  };
+  road_address: {
+    address_name: string | null; // 도로명 주소
+  };
+}
+
 export const getUserLocation = (): Promise<Coords> =>
   new Promise((resolve, reject) => {
     if (!('geolocation' in navigator)) {
@@ -21,15 +30,20 @@ export const getUserLocation = (): Promise<Coords> =>
 export const getAddressFromCoords = (
   latitude: number,
   longitude: number
-): Promise<string> =>
+): Promise<{ address: string; roadAddress: string | null }> =>
   new Promise((resolve, reject) => {
     window.kakao.maps.load(() => {
       // API가 로드될 때까지 기다림
       const geocoder = new window.kakao.maps.services.Geocoder();
-      const callback = (result: any, status: any) => {
+      const callback = (result: AddressResult[], status: string) => {
         if (status === window.kakao.maps.services.Status.OK) {
+          console.log(result);
           const address = result[0].address.address_name;
-          resolve(address);
+          let roadAddress = null;
+          if (result[0] && result[0].road_address) {
+            roadAddress = result[0].road_address.address_name;
+          }
+          resolve({ address, roadAddress });
         } else {
           reject(new Error('주소를 가져오는데 실패했습니다.'));
         }

--- a/src/utils/getUserLocation.ts
+++ b/src/utils/getUserLocation.ts
@@ -39,10 +39,9 @@ export const getAddressFromCoords = (
         if (status === window.kakao.maps.services.Status.OK) {
           console.log(result);
           const address = result[0].address.address_name;
-          let roadAddress = null;
-          if (result[0] && result[0].road_address) {
-            roadAddress = result[0].road_address.address_name;
-          }
+          const roadAddress = result[0].road_address
+            ? result[0].road_address.address_name
+            : null;
           resolve({ address, roadAddress });
         } else {
           reject(new Error('주소를 가져오는데 실패했습니다.'));

--- a/src/utils/getUserLocation.ts
+++ b/src/utils/getUserLocation.ts
@@ -4,9 +4,9 @@ interface AddressResult {
   address: {
     address_name: string; // 지번 주소
   };
-  road_address: {
+  road_address?: {
     address_name: string | null; // 도로명 주소
-  };
+  } | null;
 }
 
 export const getUserLocation = (): Promise<Coords> =>


### PR DESCRIPTION
## 📝 #108 작업 내용

> 농구장 제보에서 react-hook-forms을 쓰는 과정에서 Radio 상태 값은 제대로 업데이트가 안되고 있는 문제 발견 후 수정 완료 했습니다. Radio값은 TypeScript에서 타입이 3가지가 되어서 백엔드에 boolean -> string 값으로 타입 수정 요청했습니다.

- [x] 농구장 제보시 도로명 주소 반영(도로명 주소가 없는 곳은 지번 주소)
- [x] RadioGroup type boolean -> string으로 리팩토링
- [x] 농구장 제보 실패 모달 추가

## 💬 리뷰 요구사항
  > 현재 백엔드에서 변경사항 반영 중입니다. 반영 전까지 제보하기 실패가 나옵니다.
