### PR TITLE
# 242 커뮤니티 Table 높이 설정, 상세 글 보기 높이, 댓글 스타일링 수정

### DIFF
--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -174,7 +174,7 @@ const Page = () => {
             대관양도
           </Button>
         </div>
-        <div>
+        <div className="pb-[48px]">
           <Table
             color="primary"
             aria-label="게시글 목록"

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -43,17 +43,8 @@ const Page = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [page, setPage] = useState(1);
-  const rowsPerPage = 11;
-  const pages = useMemo(
-    () =>
-      communityBoard && tag === ''
-        ? Math.ceil((communityBoard || []).length / rowsPerPage)
-        : Math.ceil((communityBoard || []).length / rowsPerPage),
-    [communityBoard, tag]
-  );
-
   const [isMobile, setIsMobile] = useState(false);
+
   useEffect(() => {
     const handleResize = () => {
       setIsMobile(window.innerWidth < 415);
@@ -64,6 +55,16 @@ const Page = () => {
 
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  const [page, setPage] = useState(1);
+  const rowsPerPage = isMobile ? 13 : 16;
+  const pages = useMemo(
+    () =>
+      communityBoard && tag === ''
+        ? Math.ceil((communityBoard || []).length / rowsPerPage)
+        : Math.ceil((communityBoard || []).length / rowsPerPage),
+    [communityBoard, tag, rowsPerPage]
+  );
 
   const handleLink = (id: number) => {
     router.push(`/community/article/${id}`);
@@ -83,182 +84,194 @@ const Page = () => {
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="relative h-[calc(100vh-109px)] w-full overflow-y-scroll">
       <title>슬램톡 | 커뮤니티</title>
-      <div className="z-10 flex w-full transform items-center justify-center rounded-md bg-background p-1 shadow-md">
-        <input
-          aria-label="검색창"
-          value={inputData}
-          onChange={(e) => setInputData(e.target.value)}
-          placeholder="검색어를 입력해주세요"
-          className="w-11/12 p-2 focus:outline-none focus:ring-0"
-          onFocus={() => setIsFocus(true)}
-          onBlur={() => setIsFocus(false)}
-        />
-        <button
-          onClick={Search}
-          type="button"
-          aria-label="search button in community"
-          className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
-        >
-          <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
-        </button>
-      </div>
-      <div className="sm:ap flex flex-wrap justify-center py-2 sm:space-x-2 md:space-x-12 ">
-        <Button
-          onClick={() => {
-            setTag('');
-          }}
-          aria-label="태그 버튼 all"
-          size={isMobile ? 'sm' : 'md'}
-          key="all"
-          radius="full"
-          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-        >
-          전체
-        </Button>
-
-        <Button
-          onClick={() => {
-            setTag('FREE');
-            setPage(1);
-          }}
-          aria-label="태그 버튼 free"
-          size={isMobile ? 'sm' : 'md'}
-          value="FREE"
-          key="FREE"
-          radius="full"
-          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-        >
-          자유
-        </Button>
-        <Button
-          aria-label="태그 버튼 usedtrade"
-          onClick={() => {
-            setTag('USED');
-            setPage(1);
-          }}
-          size={isMobile ? 'sm' : 'md'}
-          key="USED"
-          radius="full"
-          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-        >
-          중고거래
-        </Button>
-        <Button
-          onClick={() => {
-            setTag('QUESTION');
-            setPage(1);
-          }}
-          size={isMobile ? 'sm' : 'md'}
-          aria-label="태그 버튼 question"
-          key="QUESTION"
-          radius="full"
-          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-        >
-          질문
-        </Button>
-        <Button
-          aria-label="태그 버튼 rentaltransfer"
-          onClick={() => {
-            setTag('TRANSFER');
-            setPage(1);
-          }}
-          size={isMobile ? 'sm' : 'md'}
-          key="TRANSFER"
-          radius="full"
-          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-        >
-          대관양도
-        </Button>
-      </div>
-      <div className="h-screen">
-        <Table
-          color="primary"
-          aria-label="게시글 목록"
-          fullWidth
-          bottomContent={
-            <div className="flex w-full justify-center">
-              <Pagination
-                isCompact
-                showControls
-                showShadow
-                color="primary"
-                page={page}
-                total={pages}
-                onChange={(num) => setPage(num)}
-              />
-            </div>
-          }
-        >
-          <TableHeader>
-            <TableColumn>TITLE</TableColumn>
-            <TableColumn>USER</TableColumn>
-          </TableHeader>
-
-          <TableBody items={communityBoard ?? []} loadingContent={<Spinner />}>
-            {tag === ''
-              ? (
-                  communityBoard?.slice(
-                    (page - 1) * rowsPerPage,
-                    (page - 1) * rowsPerPage + rowsPerPage
-                  ) || []
-                )
-                  .filter(
-                    (item: IBoard) =>
-                      searchKey === '' || item.title.includes(searchKey)
-                  )
-                  .map((item: IBoard) => (
-                    <TableRow
-                      className="cursor-pointer hover:bg-primary hover:text-white"
-                      onClick={() => handleLink(item.communityId)}
-                      key={item.communityId}
-                      aria-labelledby={`title-${item.communityId}`}
-                    >
-                      <TableCell className="flex-grow">{item.title}</TableCell>
-                      <TableCell>{item.userNickname}</TableCell>
-                    </TableRow>
-                  ))
-              : (
-                  categoriedBoard?.slice(
-                    (page - 1) * rowsPerPage,
-                    (page - 1) * rowsPerPage + rowsPerPage
-                  ) || []
-                )
-                  .filter(
-                    (item: IBoard) =>
-                      searchKey === '' || item.title.includes(searchKey)
-                  )
-                  .map((item: IBoard) => (
-                    <TableRow
-                      className="cursor-pointer hover:bg-primary hover:text-white"
-                      onClick={() => handleLink(item.communityId)}
-                      key={item.communityId}
-                      aria-labelledby={`title-${item.communityId}`}
-                    >
-                      <TableCell className="flex-grow">{item.title}</TableCell>
-                      <TableCell>{item.userNickname}</TableCell>
-                    </TableRow>
-                  ))}
-          </TableBody>
-        </Table>
-      </div>
-      <div className="fixed bottom-14 w-full max-w-[600px]">
-        <div className="mr-4 flex justify-end">
-          <Button
-            aria-label="Write new post"
+      <div className="">
+        <div className="z-10 flex transform items-center justify-center rounded-md bg-background p-1 shadow-md">
+          <input
+            aria-label="검색창"
+            value={inputData}
+            onChange={(e) => setInputData(e.target.value)}
+            placeholder="검색어를 입력해주세요"
+            className="w-11/12 p-2 focus:outline-none focus:ring-0"
+            onFocus={() => setIsFocus(true)}
+            onBlur={() => setIsFocus(false)}
+          />
+          <button
+            onClick={Search}
             type="button"
-            startContent={<FaPlus />}
-            className="rounded-full bg-primary text-white shadow-md"
+            aria-label="search button in community"
+            className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
+          >
+            <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
+          </button>
+        </div>
+        <div className="my-2 flex justify-between">
+          <Button
             onClick={() => {
-              if (isLoggedIn === 'true') {
-                return router.push('/community/write');
-              }
-              return router.push('/login');
+              setTag('');
+            }}
+            aria-label="태그 버튼 all"
+            size={isMobile ? 'sm' : 'md'}
+            key="all"
+            radius="full"
+            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          >
+            전체
+          </Button>
+
+          <Button
+            onClick={() => {
+              setTag('FREE');
+              setPage(1);
+            }}
+            aria-label="태그 버튼 free"
+            size={isMobile ? 'sm' : 'md'}
+            value="FREE"
+            key="FREE"
+            radius="full"
+            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          >
+            자유
+          </Button>
+          <Button
+            aria-label="태그 버튼 usedtrade"
+            onClick={() => {
+              setTag('USED');
+              setPage(1);
+            }}
+            size={isMobile ? 'sm' : 'md'}
+            key="USED"
+            radius="full"
+            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          >
+            중고거래
+          </Button>
+          <Button
+            onClick={() => {
+              setTag('QUESTION');
+              setPage(1);
+            }}
+            size={isMobile ? 'sm' : 'md'}
+            aria-label="태그 버튼 question"
+            key="QUESTION"
+            radius="full"
+            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          >
+            질문
+          </Button>
+          <Button
+            aria-label="태그 버튼 rentaltransfer"
+            onClick={() => {
+              setTag('TRANSFER');
+              setPage(1);
+            }}
+            size={isMobile ? 'sm' : 'md'}
+            key="TRANSFER"
+            radius="full"
+            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+          >
+            대관양도
+          </Button>
+        </div>
+        <div className="">
+          <Table
+            color="primary"
+            aria-label="게시글 목록"
+            fullWidth
+            bottomContent={
+              <div className="flex w-full justify-center">
+                <Pagination
+                  isCompact
+                  showControls
+                  showShadow
+                  color="primary"
+                  page={page}
+                  total={pages}
+                  onChange={(num) => setPage(num)}
+                />
+              </div>
+            }
+            classNames={{
+              wrapper: 'h-full min-h-[710px] sm:min-h-[637px]',
             }}
           >
-            글 작성하기
-          </Button>
+            <TableHeader>
+              <TableColumn>제목</TableColumn>
+              <TableColumn>글쓴이</TableColumn>
+            </TableHeader>
+
+            <TableBody
+              items={communityBoard ?? []}
+              loadingContent={<Spinner />}
+            >
+              {tag === ''
+                ? (
+                    communityBoard?.slice(
+                      (page - 1) * rowsPerPage,
+                      (page - 1) * rowsPerPage + rowsPerPage
+                    ) || []
+                  )
+                    .filter(
+                      (item: IBoard) =>
+                        searchKey === '' || item.title.includes(searchKey)
+                    )
+                    .map((item: IBoard) => (
+                      <TableRow
+                        className="cursor-pointer hover:bg-primary hover:text-white"
+                        onClick={() => handleLink(item.communityId)}
+                        key={item.communityId}
+                        aria-labelledby={`title-${item.communityId}`}
+                      >
+                        <TableCell className="flex-grow">
+                          {item.title}
+                        </TableCell>
+                        <TableCell>{item.userNickname}</TableCell>
+                      </TableRow>
+                    ))
+                : (
+                    categoriedBoard?.slice(
+                      (page - 1) * rowsPerPage,
+                      (page - 1) * rowsPerPage + rowsPerPage
+                    ) || []
+                  )
+                    .filter(
+                      (item: IBoard) =>
+                        searchKey === '' || item.title.includes(searchKey)
+                    )
+                    .map((item: IBoard) => (
+                      <TableRow
+                        className="cursor-pointer hover:bg-primary hover:text-white"
+                        onClick={() => handleLink(item.communityId)}
+                        key={item.communityId}
+                        aria-labelledby={`title-${item.communityId}`}
+                      >
+                        <TableCell className="flex-grow">
+                          {item.title}
+                        </TableCell>
+                        <TableCell>{item.userNickname}</TableCell>
+                      </TableRow>
+                    ))}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="fixed bottom-14 right-0">
+          <div className="mr-4 flex justify-end">
+            <Button
+              aria-label="Write new post"
+              type="button"
+              startContent={<FaPlus />}
+              className="rounded-full bg-primary text-white shadow-md"
+              onClick={() => {
+                if (isLoggedIn === 'true') {
+                  return router.push('/community/write');
+                }
+                return router.push('/login');
+              }}
+            >
+              글 작성하기
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -86,192 +86,183 @@ const Page = () => {
   return (
     <div className="relative h-[calc(100vh-109px)] w-full">
       <title>슬램톡 | 커뮤니티</title>
-      <div className="">
-        <div className="z-10 flex transform items-center justify-center rounded-md bg-background p-1 shadow-md">
-          <input
-            aria-label="검색창"
-            value={inputData}
-            onChange={(e) => setInputData(e.target.value)}
-            placeholder="검색어를 입력해주세요"
-            className="w-11/12 p-2 focus:outline-none focus:ring-0"
-            onFocus={() => setIsFocus(true)}
-            onBlur={() => setIsFocus(false)}
-          />
-          <button
-            onClick={Search}
+      <div className="z-10 flex transform items-center justify-center rounded-md bg-background p-1 shadow-md">
+        <input
+          aria-label="검색창"
+          value={inputData}
+          onChange={(e) => setInputData(e.target.value)}
+          placeholder="검색어를 입력해주세요"
+          className="w-11/12 p-2 focus:outline-none focus:ring-0"
+          onFocus={() => setIsFocus(true)}
+          onBlur={() => setIsFocus(false)}
+        />
+        <button
+          onClick={Search}
+          type="button"
+          aria-label="search button in community"
+          className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
+        >
+          <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
+        </button>
+      </div>
+      <div className="my-2 flex justify-between">
+        <Button
+          onClick={() => {
+            setTag('');
+          }}
+          aria-label="태그 버튼 all"
+          size={isMobile ? 'sm' : 'md'}
+          key="all"
+          radius="full"
+          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+        >
+          전체
+        </Button>
+
+        <Button
+          onClick={() => {
+            setTag('FREE');
+            setPage(1);
+          }}
+          aria-label="태그 버튼 free"
+          size={isMobile ? 'sm' : 'md'}
+          value="FREE"
+          key="FREE"
+          radius="full"
+          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+        >
+          자유
+        </Button>
+        <Button
+          aria-label="태그 버튼 usedtrade"
+          onClick={() => {
+            setTag('USED');
+            setPage(1);
+          }}
+          size={isMobile ? 'sm' : 'md'}
+          key="USED"
+          radius="full"
+          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+        >
+          중고거래
+        </Button>
+        <Button
+          onClick={() => {
+            setTag('QUESTION');
+            setPage(1);
+          }}
+          size={isMobile ? 'sm' : 'md'}
+          aria-label="태그 버튼 question"
+          key="QUESTION"
+          radius="full"
+          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+        >
+          질문
+        </Button>
+        <Button
+          aria-label="태그 버튼 rentaltransfer"
+          onClick={() => {
+            setTag('TRANSFER');
+            setPage(1);
+          }}
+          size={isMobile ? 'sm' : 'md'}
+          key="TRANSFER"
+          radius="full"
+          className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
+        >
+          대관양도
+        </Button>
+      </div>
+      <div className="pb-[48px]">
+        <Table
+          color="primary"
+          aria-label="게시글 목록"
+          fullWidth
+          bottomContent={
+            <div className="flex w-full justify-center">
+              <Pagination
+                isCompact
+                showControls
+                showShadow
+                color="primary"
+                page={page}
+                total={pages}
+                onChange={(num) => setPage(num)}
+              />
+            </div>
+          }
+          classNames={{
+            wrapper: 'h-full min-h-[710px] sm:min-h-[637px]',
+          }}
+        >
+          <TableHeader>
+            <TableColumn>제목</TableColumn>
+            <TableColumn>글쓴이</TableColumn>
+          </TableHeader>
+
+          <TableBody items={communityBoard ?? []} loadingContent={<Spinner />}>
+            {tag === ''
+              ? (
+                  communityBoard?.slice(
+                    (page - 1) * rowsPerPage,
+                    (page - 1) * rowsPerPage + rowsPerPage
+                  ) || []
+                )
+                  .filter(
+                    (item: IBoard) =>
+                      searchKey === '' || item.title.includes(searchKey)
+                  )
+                  .map((item: IBoard) => (
+                    <TableRow
+                      className="cursor-pointer hover:bg-primary hover:text-white"
+                      onClick={() => handleLink(item.communityId)}
+                      key={item.communityId}
+                      aria-labelledby={`title-${item.communityId}`}
+                    >
+                      <TableCell className="flex-grow">{item.title}</TableCell>
+                      <TableCell>{item.userNickname}</TableCell>
+                    </TableRow>
+                  ))
+              : (
+                  categoriedBoard?.slice(
+                    (page - 1) * rowsPerPage,
+                    (page - 1) * rowsPerPage + rowsPerPage
+                  ) || []
+                )
+                  .filter(
+                    (item: IBoard) =>
+                      searchKey === '' || item.title.includes(searchKey)
+                  )
+                  .map((item: IBoard) => (
+                    <TableRow
+                      className="cursor-pointer hover:bg-primary hover:text-white"
+                      onClick={() => handleLink(item.communityId)}
+                      key={item.communityId}
+                      aria-labelledby={`title-${item.communityId}`}
+                    >
+                      <TableCell className="flex-grow">{item.title}</TableCell>
+                      <TableCell>{item.userNickname}</TableCell>
+                    </TableRow>
+                  ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="fixed bottom-14 right-0">
+        <div className="mr-4 flex justify-end">
+          <Button
+            aria-label="Write new post"
             type="button"
-            aria-label="search button in community"
-            className="ml-2 mr-2 flex h-full w-8 items-center justify-center rounded-md focus:outline-none"
-          >
-            <IoSearchSharp className="w-full text-gray-400 hover:text-black" />
-          </button>
-        </div>
-        <div className="my-2 flex justify-between">
-          <Button
+            startContent={<FaPlus />}
+            className="rounded-full bg-primary text-white shadow-md"
             onClick={() => {
-              setTag('');
+              if (isLoggedIn === 'true') {
+                return router.push('/community/write');
+              }
+              return router.push('/login');
             }}
-            aria-label="태그 버튼 all"
-            size={isMobile ? 'sm' : 'md'}
-            key="all"
-            radius="full"
-            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
           >
-            전체
+            글 작성하기
           </Button>
-
-          <Button
-            onClick={() => {
-              setTag('FREE');
-              setPage(1);
-            }}
-            aria-label="태그 버튼 free"
-            size={isMobile ? 'sm' : 'md'}
-            value="FREE"
-            key="FREE"
-            radius="full"
-            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-          >
-            자유
-          </Button>
-          <Button
-            aria-label="태그 버튼 usedtrade"
-            onClick={() => {
-              setTag('USED');
-              setPage(1);
-            }}
-            size={isMobile ? 'sm' : 'md'}
-            key="USED"
-            radius="full"
-            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-          >
-            중고거래
-          </Button>
-          <Button
-            onClick={() => {
-              setTag('QUESTION');
-              setPage(1);
-            }}
-            size={isMobile ? 'sm' : 'md'}
-            aria-label="태그 버튼 question"
-            key="QUESTION"
-            radius="full"
-            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-          >
-            질문
-          </Button>
-          <Button
-            aria-label="태그 버튼 rentaltransfer"
-            onClick={() => {
-              setTag('TRANSFER');
-              setPage(1);
-            }}
-            size={isMobile ? 'sm' : 'md'}
-            key="TRANSFER"
-            radius="full"
-            className="rounded-lg bg-gray-200 text-gray-500 shadow-md hover:bg-primary hover:text-white"
-          >
-            대관양도
-          </Button>
-        </div>
-        <div className="pb-[48px]">
-          <Table
-            color="primary"
-            aria-label="게시글 목록"
-            fullWidth
-            bottomContent={
-              <div className="flex w-full justify-center">
-                <Pagination
-                  isCompact
-                  showControls
-                  showShadow
-                  color="primary"
-                  page={page}
-                  total={pages}
-                  onChange={(num) => setPage(num)}
-                />
-              </div>
-            }
-            classNames={{
-              wrapper: 'h-full min-h-[710px] sm:min-h-[637px]',
-            }}
-          >
-            <TableHeader>
-              <TableColumn>제목</TableColumn>
-              <TableColumn>글쓴이</TableColumn>
-            </TableHeader>
-
-            <TableBody
-              items={communityBoard ?? []}
-              loadingContent={<Spinner />}
-            >
-              {tag === ''
-                ? (
-                    communityBoard?.slice(
-                      (page - 1) * rowsPerPage,
-                      (page - 1) * rowsPerPage + rowsPerPage
-                    ) || []
-                  )
-                    .filter(
-                      (item: IBoard) =>
-                        searchKey === '' || item.title.includes(searchKey)
-                    )
-                    .map((item: IBoard) => (
-                      <TableRow
-                        className="cursor-pointer hover:bg-primary hover:text-white"
-                        onClick={() => handleLink(item.communityId)}
-                        key={item.communityId}
-                        aria-labelledby={`title-${item.communityId}`}
-                      >
-                        <TableCell className="flex-grow">
-                          {item.title}
-                        </TableCell>
-                        <TableCell>{item.userNickname}</TableCell>
-                      </TableRow>
-                    ))
-                : (
-                    categoriedBoard?.slice(
-                      (page - 1) * rowsPerPage,
-                      (page - 1) * rowsPerPage + rowsPerPage
-                    ) || []
-                  )
-                    .filter(
-                      (item: IBoard) =>
-                        searchKey === '' || item.title.includes(searchKey)
-                    )
-                    .map((item: IBoard) => (
-                      <TableRow
-                        className="cursor-pointer hover:bg-primary hover:text-white"
-                        onClick={() => handleLink(item.communityId)}
-                        key={item.communityId}
-                        aria-labelledby={`title-${item.communityId}`}
-                      >
-                        <TableCell className="flex-grow">
-                          {item.title}
-                        </TableCell>
-                        <TableCell>{item.userNickname}</TableCell>
-                      </TableRow>
-                    ))}
-            </TableBody>
-          </Table>
-        </div>
-        <div className="fixed bottom-14 right-0">
-          <div className="mr-4 flex justify-end">
-            <Button
-              aria-label="Write new post"
-              type="button"
-              startContent={<FaPlus />}
-              className="rounded-full bg-primary text-white shadow-md"
-              onClick={() => {
-                if (isLoggedIn === 'true') {
-                  return router.push('/community/write');
-                }
-                return router.push('/login');
-              }}
-            >
-              글 작성하기
-            </Button>
-          </div>
         </div>
       </div>
     </div>

--- a/src/app/community/[tag]/page.tsx
+++ b/src/app/community/[tag]/page.tsx
@@ -84,7 +84,7 @@ const Page = () => {
   };
 
   return (
-    <div className="relative h-[calc(100vh-109px)] w-full overflow-y-scroll">
+    <div className="relative h-[calc(100vh-109px)] w-full">
       <title>슬램톡 | 커뮤니티</title>
       <div className="">
         <div className="z-10 flex transform items-center justify-center rounded-md bg-background p-1 shadow-md">
@@ -174,7 +174,7 @@ const Page = () => {
             대관양도
           </Button>
         </div>
-        <div className="">
+        <div>
           <Table
             color="primary"
             aria-label="게시글 목록"

--- a/src/app/community/article/[id]/[edit]/page.tsx
+++ b/src/app/community/article/[id]/[edit]/page.tsx
@@ -28,9 +28,6 @@ const Page = () => {
       setEditedContent('');
       router.push(`/community/article/${params.id}`);
     },
-    onError: (err) => {
-      console.log(err);
-    },
   });
 
   const onClickImageUpload = useCallback(() => {

--- a/src/app/community/article/[id]/page.tsx
+++ b/src/app/community/article/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@nextui-org/button';
 import { useParams, useRouter } from 'next/navigation';
-import { Avatar, Tooltip, useDisclosure, Spinner } from '@nextui-org/react';
+import { Avatar, useDisclosure, Spinner } from '@nextui-org/react';
 import { IoChevronBackSharp } from 'react-icons/io5';
 // import { FaHeart } from 'react-icons/fa';
 
@@ -207,11 +207,14 @@ const Page = () => {
                 입력
               </Button>
             ) : (
-              <Tooltip content="로그인이 필요한 기능입니다">
-                <Button radius="sm" color="primary" onClick={handlePostComment}>
-                  입력
-                </Button>
-              </Tooltip>
+              <Button
+                isDisabled
+                radius="sm"
+                color="primary"
+                onClick={handlePostComment}
+              >
+                입력
+              </Button>
             )}
           </div>
           <CommentList commentListData={articleData?.comments} />

--- a/src/app/community/article/[id]/page.tsx
+++ b/src/app/community/article/[id]/page.tsx
@@ -68,9 +68,6 @@ const Page = () => {
     mutationFn: () => postComment(commentData),
   });
   const handlePostComment = () => {
-    if (!loginData) {
-      router.push('/login');
-    }
     if (comment !== '') {
       setCommentData({
         communityId: +params.id,
@@ -99,14 +96,14 @@ const Page = () => {
   };
   if (isLoading) {
     return (
-      <div className="align-center flex h-screen justify-center">
+      <div className="align-center flex h-[calc(100vh-109px)] w-full justify-center">
         <Spinner size="lg" color="primary" />
       </div>
     ); // 로딩 중일 때 로딩 화면을 표시합니다.
   }
 
   return (
-    <div className="h-[90vh]">
+    <div className="relative h-[calc(100vh-109px)] w-full overflow-hidden">
       <UserProfile isOpen={isOpen} userId={writerId} onClose={onClose} />
       {articleData ? (
         <div>
@@ -122,14 +119,14 @@ const Page = () => {
             />
             <h1 className="flex-grow text-center">{articleData.title}</h1>
           </div>
-          <div className="flex h-[295px] flex-col">
+          <div className="flex flex-col">
             <div aria-label="contentsCard">
               <div
                 aria-label="유저 아바타"
                 className="mt-1 flex items-center border-b-1 sm:space-x-[60px] md:space-x-[260px]"
                 style={{ cursor: 'pointer' }}
               >
-                <div className="flex items-center">
+                <div className="ml-1 flex items-center p-1">
                   <Avatar
                     onClick={() => {
                       onOpen();
@@ -139,17 +136,20 @@ const Page = () => {
                   />
                   <p
                     aria-label="작성자 닉네임"
-                    className="w-[180px] text-lg font-bold"
+                    className="text-md w-[180px] font-bold"
                   >
                     {articleData.userNickname}
                   </p>
                 </div>
-                <p aria-label="작성일자" className="w-[100px] text-gray-400">
+                <p
+                  aria-label="작성일자"
+                  className="w-[100px] text-sm text-gray-400"
+                >
                   {articleData.updatedAt.toString().split('T')[0]}
                 </p>
               </div>
 
-              <div className="h-[200px] border-b-2">
+              <div className="min-h-[200px] border-b-2">
                 <p aria-label="게시글 컨텐츠" className="m-2">
                   {articleData.content}
                 </p>
@@ -196,28 +196,27 @@ const Page = () => {
           <div className="flex" aria-label="댓글 입력">
             <input
               placeholder="댓글을 입력해주세요"
-              className="w-11/12 rounded-md bg-background p-1 p-2 shadow-md focus:outline-none focus:ring-0"
+              className="w-11/12 rounded-md bg-background p-2 shadow-md focus:outline-none focus:ring-0"
               value={comment}
               onChange={(e) => {
                 setComment(e.target.value);
               }}
             />
-            <Tooltip
-              content={loginData !== null ? '' : '로그인이 필요한 기능입니다'}
-            >
-              <Button
-                className="w-[10px] hover:bg-primary hover:text-white"
-                onClick={handlePostComment}
-              >
+            {loginData ? (
+              <Button radius="sm" color="primary" onClick={handlePostComment}>
                 입력
               </Button>
-            </Tooltip>
+            ) : (
+              <Tooltip content="로그인이 필요한 기능입니다">
+                <Button radius="sm" color="primary" onClick={handlePostComment}>
+                  입력
+                </Button>
+              </Tooltip>
+            )}
           </div>
           <CommentList commentListData={articleData?.comments} />
         </div>
-      ) : (
-        <p>404 not found</p>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/src/app/community/components/commentItem.tsx
+++ b/src/app/community/components/commentItem.tsx
@@ -1,6 +1,5 @@
 import { deleteComment } from '@/services/community/comment/deleteComment';
 import { patchComment } from '@/services/community/comment/patchComment';
-
 import { useMutation, useQuery } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { getOtherUserData } from '@/services/user/getOtherUserData';
@@ -61,11 +60,11 @@ const CommentItem: React.FC<ICommentItemProps> = ({
   return (
     <div
       key={commentId}
-      className="border-gray mt-2 flex items-center border-b-2"
+      className="border-gray mt-2 flex items-center border-b-1"
     >
       <UserProfile isOpen={isOpen} userId={userId} onClose={onClose} />
 
-      <div aria-label="작성자 정보" style={{ cursor: 'pointer' }}>
+      <div aria-label="작성자 정보" className="cursor-pointer p-2">
         <Avatar
           size="md"
           src={writerUserInfo?.imageUrl}
@@ -84,29 +83,34 @@ const CommentItem: React.FC<ICommentItemProps> = ({
           }}
         />
       ) : (
-        <div className="mt-2">
-          <p className="mb-1 ms-5  font-bold">{writerUserInfo?.nickname}</p>
-          <h2 className="ms-5 h-10 w-[460px] sm:w-[240px]">{content}</h2>
+        <div className="flex w-full justify-between">
+          <div className="my-2 ml-1 flex flex-col">
+            <p className="font-bold">{writerUserInfo?.nickname}</p>
+            <p className="">{content}</p>
+          </div>
+          {loginUserData?.id === userId && (
+            <div
+              aria-label="comment button group"
+              className="my-2 mr-4 flex flex-col break-keep text-sm"
+            >
+              <button
+                onClick={handleEdit}
+                className="text-gray-600 hover:text-primary"
+                type="button"
+              >
+                수정
+              </button>
+              <button
+                onClick={handleDelete}
+                type="button"
+                className="text-gray-600 hover:text-primary"
+              >
+                삭제
+              </button>
+            </div>
+          )}
         </div>
       )}
-      {loginUserData?.id === userId ? (
-        <div aria-label="comment button group" className="w-40">
-          <button
-            onClick={handleEdit}
-            className="text-gray-600 hover:text-primary"
-            type="button"
-          >
-            수정
-          </button>
-          <button
-            onClick={handleDelete}
-            type="button"
-            className="mx-3 text-gray-600 hover:text-primary"
-          >
-            삭제
-          </button>
-        </div>
-      ) : null}
     </div>
   );
 };

--- a/src/app/community/components/commentList.tsx
+++ b/src/app/community/components/commentList.tsx
@@ -7,7 +7,7 @@ interface ICommentListProps {
 }
 
 const CommentList: React.FC<ICommentListProps> = ({ commentListData }) => (
-  <div className="h-fit min-h-[400px] overflow-y-auto sm:h-[340px]">
+  <div className="h-[480px] overflow-x-scroll pb-4">
     {commentListData?.map((i: ICommentItemProps) => (
       <div key={i.commentId}>
         <CommentItem

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -111,7 +111,7 @@ const Home = () => {
                 </Link>
               </Card>
             ) : (
-              <div className="flex min-h-[100px] items-center justify-center rounded-medium bg-gray-100">
+              <div className="flex min-h-[130px] items-center justify-center rounded-medium bg-gray-100">
                 <div className="text-md m-2 h-[50%] text-gray-400">
                   예정된 매칭이 없습니다.
                 </div>


### PR DESCRIPTION
## 📝 #242 작업 내용

> 커뮤니티 스타일링 수정, 개선점 파악

### 스크린샷
<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/363d820d-2a68-44d0-bc24-9a0b8c5890d9" width="33%">
이전

<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/bd1c08b4-afa2-4cbe-b0ca-6a949eebb082" width="33%">
이후

<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/40bf2874-bf10-4f2b-97be-a9e5855eb2ec" width="33%">
이전

<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/7709fb67-1966-4444-86e9-f46aa2185241" width="33%">
이후


## 💬 리뷰 요구사항
- 👀 같이 리뷰 필요
> [🌟🌟 커뮤니티 개선 사항](https://www.notion.so/acfad2e01f904b1ab4880b06e348d91d)
> 생각보다 고칠 부분이 많아서 일단 1차로 완료했고 개선 사항, 이슈 문서에 정리해놨습니다!

> 현재 **댓글 수정, 댓글 길게 쓸 때 스타일링 / 카테고리 설정이나 검색시 페이지네이션이 새로 되지 않는 문제**가 먼저 고쳐야하는 문제로 파악됩니다.

> 높이 설정은 [Next UI 문서](https://nextui.org/docs/components/table)를 보고 다음과 같이 설정하고 페이지 개수를 조정해 일단 맞춰놨습니다.(PRO 환경에서는 딱 맞게 보이고 SE에서는 조금 내려야 페이지네이션이 보입니다). Next UI 커스텀 스타일링시 다음과 같이 classNames, 요소명 이용해주세요!
> 
```typescript
            classNames={{
              wrapper: 'h-full min-h-[710px] sm:min-h-[637px]',
            }}
 ```

> 코드를 살펴보니 프론트엔드끼리 코드 일관화가 안되어 있는거 같아 이 부분 개선 필요해 보입니다.
> 팀원끼리 공유해야 되는 내용 꼭 공유해주시고 다른 사람 글 잘 확인부탁드립니다!
