### PR TITLE
#265 매칭 페이지 삭제 버튼 추가 / 삭제, 모집완료시 확인 모달 추가

### DIFF
--- a/src/app/matching/components/CheckModal.tsx
+++ b/src/app/matching/components/CheckModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@nextui-org/react';
+
+const CheckModal = ({
+  isOpen,
+  onClose,
+  title,
+  content,
+  leftBtn,
+  rightBtn,
+  leftFunc,
+  rightFunc,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  content: string;
+  leftBtn: string;
+  rightBtn: string;
+  leftFunc: () => void;
+  rightFunc: () => void;
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose} placement="center">
+    <ModalContent>
+      {() => (
+        <>
+          <ModalHeader className="flex flex-col gap-1">{title}</ModalHeader>
+          <ModalBody>
+            <p>{content}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="danger" variant="light" onPress={leftFunc}>
+              {leftBtn}
+            </Button>
+            <Button color="primary" onPress={rightFunc}>
+              {rightBtn}
+            </Button>
+          </ModalFooter>
+        </>
+      )}
+    </ModalContent>
+  </Modal>
+);
+
+export default CheckModal;

--- a/src/app/matching/mate-details/[postId]/page.tsx
+++ b/src/app/matching/mate-details/[postId]/page.tsx
@@ -29,15 +29,20 @@ const MateDetailsPage = () => {
     onClose: handleCompleteRecruitModalClose,
   } = useDisclosure();
   const {
+    isOpen: isCompleteConfirmationModalOpen,
+    onOpen: handleCompleteConfirmationModalOpen,
+    onClose: handleCompleteConfirmationModalClose,
+  } = useDisclosure();
+  const {
     isOpen: isProfileOpen,
     onOpen: handleProfileOpen,
     onClose: handleProfileClose,
   } = useDisclosure();
+
   const { error, data: user } = useQuery({
     queryKey: ['loginData'],
     queryFn: getUserData,
   });
-
   if (error) {
     console.log({ error });
   }
@@ -132,6 +137,8 @@ const MateDetailsPage = () => {
   });
 
   const handleFinishRecruitment = () => {
+    handleCompleteConfirmationModalClose();
+
     try {
       patchPostStatusMutation.mutate();
 
@@ -157,6 +164,10 @@ const MateDetailsPage = () => {
       console.error(err);
       alert('모집 완료 처리 중 오류가 발생했습니다.');
     }
+  };
+
+  const completeConfirmationModalLeftFunc = () => {
+    handleCompleteConfirmationModalClose();
   };
 
   const completeRecruitModalLeftFunc = () => {
@@ -317,7 +328,7 @@ const MateDetailsPage = () => {
               <Button
                 color="primary"
                 className="mx-1"
-                onClick={handleFinishRecruitment}
+                onClick={handleCompleteConfirmationModalOpen}
               >
                 모집 완료
               </Button>
@@ -346,6 +357,17 @@ const MateDetailsPage = () => {
           </Button>
         )}
       </div>
+      {/* 모집 완료 확인 모달 */}
+      <CheckModal
+        isOpen={isCompleteConfirmationModalOpen}
+        onClose={handleCompleteConfirmationModalClose}
+        title="메이트 찾기 모집 완료"
+        content="정말로 모집을 완료하시겠습니까?"
+        leftBtn="닫기"
+        rightBtn="모집 완료"
+        leftFunc={completeConfirmationModalLeftFunc}
+        rightFunc={handleFinishRecruitment}
+      />
       {/* 모집 완료 안내 모달 */}
       <CheckModal
         isOpen={isCompleteRecruitModalOpen}

--- a/src/app/matching/mate-details/[postId]/page.tsx
+++ b/src/app/matching/mate-details/[postId]/page.tsx
@@ -2,17 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import {
-  Snippet,
-  Button,
-  Avatar,
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  useDisclosure,
-} from '@nextui-org/react';
+import { Snippet, Button, Avatar, useDisclosure } from '@nextui-org/react';
 import axiosInstance from '@/app/api/axiosInstance';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useParams, useRouter } from 'next/navigation';
@@ -23,6 +13,7 @@ import UserProfile from '@/app/components/profile/UserProfile';
 import { FaTrashCan } from 'react-icons/fa6';
 import MateApplicantList from '../../components/MateApplicantList';
 import { MatePost } from '../../../../types/matching/mateDataType';
+import CheckModal from '../../components/CheckModal';
 
 interface MateChatRoomType {
   participants: number[];
@@ -32,7 +23,11 @@ interface MateChatRoomType {
 }
 
 const MateDetailsPage = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isCompleteRecruitModalOpen,
+    onOpen: handleCompleteRecruitModalOpen,
+    onClose: handleCompleteRecruitModalClose,
+  } = useDisclosure();
   const {
     isOpen: isProfileOpen,
     onOpen: handleProfileOpen,
@@ -118,7 +113,7 @@ const MateDetailsPage = () => {
     onSuccess: (response) => {
       const newChatRoomId = response.data.results;
       setChatRoomId(newChatRoomId);
-      onOpen();
+      handleCompleteRecruitModalOpen();
     },
     onError: (er) => {
       console.error(er);
@@ -162,6 +157,14 @@ const MateDetailsPage = () => {
       console.error(err);
       alert('모집 완료 처리 중 오류가 발생했습니다.');
     }
+  };
+
+  const completeRecruitModalLeftFunc = () => {
+    handleCompleteRecruitModalClose();
+  };
+
+  const completeRecruitModalRightFunc = () => {
+    router.push(`/chatting/chatroom/${chatRoomId}`);
   };
 
   useEffect(() => {
@@ -343,34 +346,18 @@ const MateDetailsPage = () => {
           </Button>
         )}
       </div>
-      <Modal isOpen={isOpen} onClose={onClose} placement="center">
-        <ModalContent>
-          {() => (
-            <>
-              <ModalHeader className="flex flex-col gap-1">
-                메이트 찾기 모집 완료
-              </ModalHeader>
-              <ModalBody>
-                <p>메이트 찾기 모집이 완료되었습니다.</p>
-                <p>메이트 채팅방이 개설되었습니다.</p>
-              </ModalBody>
-              <ModalFooter>
-                <Button color="danger" variant="light" onPress={onClose}>
-                  닫기
-                </Button>
-                <Button
-                  color="primary"
-                  onPress={() =>
-                    router.push(`/chatting/chatroom/${chatRoomId}`)
-                  }
-                >
-                  채팅방으로 이동
-                </Button>
-              </ModalFooter>
-            </>
-          )}
-        </ModalContent>
-      </Modal>
+      {/* 모집 완료 안내 모달 */}
+      <CheckModal
+        isOpen={isCompleteRecruitModalOpen}
+        onClose={handleCompleteRecruitModalClose}
+        title="메이트 찾기 모집 완료"
+        content="메이트 찾기 모집이 완료되었습니다. 단체 채팅방이
+        생성되었습니다."
+        leftBtn="닫기"
+        rightBtn="채팅방으로 이동"
+        leftFunc={completeRecruitModalLeftFunc}
+        rightFunc={completeRecruitModalRightFunc}
+      />
     </div>
   );
 };

--- a/src/app/matching/mate-details/[postId]/page.tsx
+++ b/src/app/matching/mate-details/[postId]/page.tsx
@@ -144,31 +144,31 @@ const MateDetailsPage = () => {
   const handleFinishRecruitment = () => {
     handleCompleteConfirmationModalClose();
 
-    try {
-      patchPostStatusMutation.mutate();
+    patchPostStatusMutation.mutate(undefined, {
+      onSuccess: () => {
+        const acceptedParticipantIds =
+          data?.participants
+            .filter((participant) => participant.applyStatus === 'ACCEPTED')
+            .map((acceptedParticipant) => acceptedParticipant.participantId) ||
+          [];
+        const participantsIds = [
+          data?.writerId,
+          ...acceptedParticipantIds,
+        ].filter((id): id is number => id !== undefined);
 
-      const acceptedParticipantIds =
-        data?.participants
-          .filter((participant) => participant.applyStatus === 'ACCEPTED')
-          .map((acceptedParticipant) => acceptedParticipant.participantId) ||
-        [];
-      const participantsIds = [
-        data?.writerId,
-        ...acceptedParticipantIds,
-      ].filter((id): id is number => id !== undefined);
+        const newRoomData: MateChatRoomType = {
+          participants: participantsIds,
+          roomType: 'TM',
+          together_id: data?.matePostId.toString() ?? '',
+          name: data?.title ?? '',
+        };
 
-      const newRoomData: MateChatRoomType = {
-        participants: participantsIds,
-        roomType: 'TM',
-        together_id: data?.matePostId.toString() ?? '',
-        name: data?.title ?? '',
-      };
-
-      createMateChatRoomMutation.mutate(newRoomData);
-    } catch (err) {
-      console.error(err);
-      alert('모집 완료 처리 중 오류가 발생했습니다.');
-    }
+        createMateChatRoomMutation.mutate(newRoomData);
+      },
+      onError: () => {
+        alert('모집 완료 처리 중 오류가 발생했습니다.');
+      },
+    });
   };
 
   useEffect(() => {
@@ -393,6 +393,7 @@ const MateDetailsPage = () => {
         leftFunc={completeRecruitModalLeftFunc}
         rightFunc={completeRecruitModalRightFunc}
       />
+      {/* 게시글 삭제 확인 모달 */}
       <CheckModal
         isOpen={isDeleteConfirmationModalOpen}
         onClose={handleDeleteConfirmationModalClose}

--- a/src/app/matching/mate-details/[postId]/page.tsx
+++ b/src/app/matching/mate-details/[postId]/page.tsx
@@ -34,6 +34,11 @@ const MateDetailsPage = () => {
     onClose: handleCompleteConfirmationModalClose,
   } = useDisclosure();
   const {
+    isOpen: isDeleteConfirmationModalOpen,
+    onOpen: handleDeleteConfirmationModalOpen,
+    onClose: handleDeleteConfirmationModalClose,
+  } = useDisclosure();
+  const {
     isOpen: isProfileOpen,
     onOpen: handleProfileOpen,
     onClose: handleProfileClose,
@@ -166,18 +171,6 @@ const MateDetailsPage = () => {
     }
   };
 
-  const completeConfirmationModalLeftFunc = () => {
-    handleCompleteConfirmationModalClose();
-  };
-
-  const completeRecruitModalLeftFunc = () => {
-    handleCompleteRecruitModalClose();
-  };
-
-  const completeRecruitModalRightFunc = () => {
-    router.push(`/chatting/chatroom/${chatRoomId}`);
-  };
-
   useEffect(() => {
     if (data) {
       const formatDate = (dateString: string) => {
@@ -215,6 +208,26 @@ const MateDetailsPage = () => {
       alert('로그인 후 이용할 수 있습니다.');
       router.push(`/login`);
     }
+  };
+
+  const completeConfirmationModalLeftFunc = () => {
+    handleCompleteConfirmationModalClose();
+  };
+
+  const completeRecruitModalLeftFunc = () => {
+    handleCompleteRecruitModalClose();
+  };
+
+  const completeRecruitModalRightFunc = () => {
+    router.push(`/chatting/chatroom/${chatRoomId}`);
+  };
+
+  const deleteConfirmationModalLeftFunc = () => {
+    handleDeleteConfirmationModalClose();
+  };
+
+  const deleteConfirmationModalRightFunc = () => {
+    deleteRecruitment();
   };
 
   return (
@@ -341,7 +354,7 @@ const MateDetailsPage = () => {
                 color="default"
                 isIconOnly
                 className="mx-1 w-[30px] bg-gray-400 px-[0px] text-white"
-                onClick={deleteRecruitment}
+                onClick={handleDeleteConfirmationModalOpen}
               >
                 <FaTrashCan />
               </Button>
@@ -379,6 +392,16 @@ const MateDetailsPage = () => {
         rightBtn="채팅방으로 이동"
         leftFunc={completeRecruitModalLeftFunc}
         rightFunc={completeRecruitModalRightFunc}
+      />
+      <CheckModal
+        isOpen={isDeleteConfirmationModalOpen}
+        onClose={handleDeleteConfirmationModalClose}
+        title="상대팀 찾기 게시글 삭제"
+        content="정말로 게시글을 삭제하시겠습니까?"
+        leftBtn="닫기"
+        rightBtn="삭제"
+        leftFunc={deleteConfirmationModalLeftFunc}
+        rightFunc={deleteConfirmationModalRightFunc}
       />
     </div>
   );

--- a/src/app/matching/mate-details/[postId]/page.tsx
+++ b/src/app/matching/mate-details/[postId]/page.tsx
@@ -20,6 +20,7 @@ import { AxiosResponse } from 'axios';
 import LocalStorage from '@/utils/localstorage';
 import { getUserData } from '@/services/user/getUserData';
 import UserProfile from '@/app/components/profile/UserProfile';
+import { FaTrashCan } from 'react-icons/fa6';
 import MateApplicantList from '../../components/MateApplicantList';
 import { MatePost } from '../../../../types/matching/mateDataType';
 
@@ -74,13 +75,15 @@ const MateDetailsPage = () => {
   };
   const isWriter = user?.id === writer.userId;
 
-  // const deleteRecruitment = async (): Promise<AxiosResponse> => {
-  //   const response = await axiosInstance.delete<AxiosResponse>(
-  //     `/api/mate/${postId}`
-  //   );
+  const deleteRecruitment = async (): Promise<AxiosResponse> => {
+    const response = await axiosInstance.delete<AxiosResponse>(
+      `/api/mate/${postId}`
+    );
 
-  //   return response;
-  // };
+    router.push(`/matching?tab=mate`);
+
+    return response;
+  };
 
   const patchCompleteRecruitment = async (): Promise<AxiosResponse> => {
     const response = await axiosInstance.patch<AxiosResponse>(
@@ -310,16 +313,24 @@ const MateDetailsPage = () => {
             <>
               <Button
                 color="primary"
-                className="mx-2"
+                className="mx-1"
                 onClick={handleFinishRecruitment}
               >
                 모집 완료
               </Button>
               <Link href={`/matching/mate-details/${data?.matePostId}/revise`}>
-                <Button color="default" className="mx-2 bg-gray-400 text-white">
+                <Button color="default" className="mx-1 bg-gray-400 text-white">
                   모집글 수정
                 </Button>
               </Link>
+              <Button
+                color="default"
+                isIconOnly
+                className="mx-1 w-[30px] bg-gray-400 px-[0px] text-white"
+                onClick={deleteRecruitment}
+              >
+                <FaTrashCan />
+              </Button>
             </>
           )
         ) : (

--- a/src/app/matching/team-details/[postId]/page.tsx
+++ b/src/app/matching/team-details/[postId]/page.tsx
@@ -33,11 +33,11 @@ const TeamDetailsPage = () => {
     onOpen: handleCompleteConfirmationModalOpen,
     onClose: handleCompleteConfirmationModalClose,
   } = useDisclosure();
-  // const {
-  //   isOpen: isDeleteConfirmationModalOpen,
-  //   onOpen: handleDeleteConfirmationModalOpen,
-  //   onClose: handleDeleteConfirmationModalClose,
-  // } = useDisclosure();
+  const {
+    isOpen: isDeleteConfirmationModalOpen,
+    onOpen: handleDeleteConfirmationModalOpen,
+    onClose: handleDeleteConfirmationModalClose,
+  } = useDisclosure();
   const {
     isOpen: isProfileOpen,
     onOpen: handleProfileOpen,
@@ -229,6 +229,14 @@ const TeamDetailsPage = () => {
     router.push(`/chatting/chatroom/${chatRoomId}`);
   };
 
+  const deleteConfirmationModalLeftFunc = () => {
+    handleDeleteConfirmationModalClose();
+  };
+
+  const deleteConfirmationModalRightFunc = () => {
+    deleteRecruitment();
+  };
+
   return (
     <div className="mx-[16px] mt-4 rounded-md border-2">
       {/* 유저 프로필 */}
@@ -361,7 +369,7 @@ const TeamDetailsPage = () => {
                 color="default"
                 isIconOnly
                 className="mx-1 w-[30px] bg-gray-400 px-[0px] text-white"
-                onClick={deleteRecruitment}
+                onClick={handleDeleteConfirmationModalOpen}
               >
                 <FaTrashCan />
               </Button>
@@ -377,6 +385,7 @@ const TeamDetailsPage = () => {
           </Button>
         )}
       </div>
+      {/* 모집 완료 확인 모달 */}
       <CheckModal
         isOpen={isCompleteConfirmationModalOpen}
         onClose={handleCompleteConfirmationModalClose}
@@ -387,6 +396,7 @@ const TeamDetailsPage = () => {
         leftFunc={completeConfirmationModalLeftFunc}
         rightFunc={handleFinishRecruitment}
       />
+      {/* 모집 완료 안내 모달 */}
       <CheckModal
         isOpen={isCompleteRecruitModalOpen}
         onClose={handleCompleteRecruitModalClose}
@@ -397,6 +407,17 @@ const TeamDetailsPage = () => {
         rightBtn="채팅방으로 이동"
         leftFunc={completeRecruitModalLeftFunc}
         rightFunc={completeRecruitModalRightFunc}
+      />
+      {/* 게시글 삭제 확인 모달 */}
+      <CheckModal
+        isOpen={isDeleteConfirmationModalOpen}
+        onClose={handleDeleteConfirmationModalClose}
+        title="상대팀 찾기 게시글 삭제"
+        content="정말로 게시글을 삭제하시겠습니까?"
+        leftBtn="닫기"
+        rightBtn="삭제"
+        leftFunc={deleteConfirmationModalLeftFunc}
+        rightFunc={deleteConfirmationModalRightFunc}
       />
     </div>
   );


### PR DESCRIPTION
## 📝 #265 작업 내용

- [x] 상대팀매칭/메이트매칭 삭제 버튼 추가
- [x] 확인 모달 컴포넌트 분리
- [x] 삭제, 모집완료시 확인 모달 추가
- [x] 모집 완료 로직에서 에러가 나더라도 채팅방 생성 로직까지 실행되는 문제 수정   

## 💬 리뷰 요구사항
- 확인용 모달을 3개를 써야해서 총 열릴 수 있는 모달이 4개여서 isOpen, onOpen, onClose 명칭을 전부 명시적으로 써주었습니다.
-> 전부 is(00모달)Open, handle(00모달)Open, handle(00모달)Close 이런식으로 바꿨습니다.
- 확인용 모달 컴포넌트를 따로 만들어서 버튼 2개짜리 모달은 isOpen, onClose, 제목, 내용, 왼쪽버튼, 오른쪽버튼, 왼쪽버튼 함수, 오른쪽버튼 함수를 props로 받게끔 설정해주었습니다. 
<image src="https://github.com/SlamTalk/slam-talk-frontend/assets/100774811/0d28168f-ad08-4f40-b810-51c48e433a5e" width=50%/>

- 버그 수정 사항
기존에 모집 완료 버튼을 누르면 게시글이 모집 완료 상태로 업데이트 됨과 동시에 채팅방이 생성되어야 해서 하나에 함수에서 동작하도록 코드를 짜놓았는데, 모집 완료 상태로 업데이트하는 함수와 채팅방 생성 함수가 둘 다 비동기적으로 처리되는 함수들이기 때문에, 모집 완료 로직에서 에러가 나더라도 채팅방 생성 로직까지 실행하는 문제가 있었음.
-> 실행컨텍스트를 분리함으로써 해결
<image src="https://github.com/SlamTalk/slam-talk-frontend/assets/100774811/025a2eed-da7d-4de0-8930-6099f8c5bd5f" width=50%/>



