### PR TITLE
#251 fix: key event type 정확히 수정

### DIFF
--- a/src/app/(auth)/find-password/layout.tsx
+++ b/src/app/(auth)/find-password/layout.tsx
@@ -11,7 +11,7 @@ const FindPasswordlayout = ({ children }: { children: React.ReactNode }) => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/login/email/page.tsx
+++ b/src/app/(auth)/login/email/page.tsx
@@ -82,7 +82,7 @@ const EmailLogin = () => {
   };
   const handleToggleVisibility = () => setIsVisible(!isVisible);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Enter') {
       handleLogin();
     }

--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -11,7 +11,7 @@ const Loginlayout = ({ children }: { children: React.ReactNode }) => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/my-page/mate-matching-list/page.tsx
+++ b/src/app/(auth)/my-page/mate-matching-list/page.tsx
@@ -17,7 +17,7 @@ const MateMatchingList = () => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/my-page/page.tsx
+++ b/src/app/(auth)/my-page/page.tsx
@@ -38,7 +38,7 @@ const MyPage = () => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/my-page/profile/page.tsx
+++ b/src/app/(auth)/my-page/profile/page.tsx
@@ -136,7 +136,7 @@ const MyProfile = () => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/my-page/settings/change-password/page.tsx
+++ b/src/app/(auth)/my-page/settings/change-password/page.tsx
@@ -37,7 +37,7 @@ const ChangePassword = () => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/my-page/settings/page.tsx
+++ b/src/app/(auth)/my-page/settings/page.tsx
@@ -28,7 +28,7 @@ const MyPageSettings = () => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }
@@ -38,7 +38,7 @@ const MyPageSettings = () => {
     onOpen();
   };
 
-  const handleKeyDownLogout = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDownLogout = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleLogout();
     }
@@ -49,7 +49,7 @@ const MyPageSettings = () => {
   };
 
   const handleKeyDownMoveToChangePassword = (
-    e: React.KeyboardEvent<HTMLInputElement>
+    e: React.KeyboardEvent<HTMLDivElement>
   ) => {
     if (e.key === 'Enter') {
       handleGoChangePassword();

--- a/src/app/(auth)/my-page/team-matching-list/page.tsx
+++ b/src/app/(auth)/my-page/team-matching-list/page.tsx
@@ -17,7 +17,7 @@ const TeamMatchingList = () => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/signup/components/EmailValidation.tsx
+++ b/src/app/(auth)/signup/components/EmailValidation.tsx
@@ -87,7 +87,7 @@ const EmailValidation: React.FC<EmailValidateProps> = ({ onEmailValidate }) => {
     router.back();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleGoBack();
     }

--- a/src/app/(auth)/signup/components/NicknamePassword.tsx
+++ b/src/app/(auth)/signup/components/NicknamePassword.tsx
@@ -133,7 +133,7 @@ const NicknamePassword: React.FC<EmailProps> = ({ validEmail }) => {
     onOpen();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleShowAlert();
     }

--- a/src/app/admin/components/AdminUserAvatar.tsx
+++ b/src/app/admin/components/AdminUserAvatar.tsx
@@ -31,7 +31,7 @@ const AdminUserAvatar: React.FC<AdminUserAvatarProps> = ({ userId }) => {
     return null;
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       handleAvatarClick();
     }


### PR DESCRIPTION
## 📝 #251 작업 내용

> handleKeyDown 함수를 복붙하면서 enter key event 추가시 html element type 명시가 잘못된 부분 수정 완료했습니다.

- [x] enter key event 수정 완료

## 💬 리뷰 요구사항

- 👀 같이 리뷰 필요
```typescript
e: React.KeyboardEvent
```
위와 같이 명시해도 문제 없지만 보다 정확한 타입 기입을 위해 요소를 명시해줬습니다.

```typescript
const handleKeyDown= (event: React.KeyboardEvent) => {
  if (event.target instanceof HTMLInputElement && event.key === "Enter") {
    event.target.blur();
    onCTAButtonClick(event);
  }
};
```
이런식으로 instanceof를 활용해서 인스턴스화된 객체 타입을 판별해줄 수도 있지만 직접 명시해주는 것이 '함수가 어떤 종류의 이벤트를 기대하고 있는지 명확히 드러나므로 코드를 읽는 사람이 더 빠르게 이해'할 수 있다는 gpt 의견이 있어서
```typescript
e: React.KeyboardEvent<HTMLDivElement>
```
이와 같이 명시해줬습니다.
**key event 추가시 이와 같이 팀 전체에서 보다 자세하게 정확한 타입 지정하면 좋을 것 같습니다.**

resolved: #251 