### PR TITLE
#295 google analytics 연결, layout 리팩토링

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "project": "./tsconfig.json"
   },
   "rules": {
+    "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
     "linebreak-style": 0,
     "import/no-extraneous-dependencies": [

--- a/src/app/(auth)/my-page/page.tsx
+++ b/src/app/(auth)/my-page/page.tsx
@@ -21,7 +21,7 @@ import {
 import Link from 'next/link';
 import LocalStorage from '@/utils/localstorage';
 import ThemeSwitcher from '@/app/components/ThemeSwitcher';
-import KakaoChannelImg from './components/KakaoChannel';
+// import KakaoChannelImg from './components/KakaoChannel';
 
 const MyPage = () => {
   const router = useRouter();
@@ -143,11 +143,11 @@ const MyPage = () => {
             </div>
           </div>
           <hr className="w-90 my-4 h-px bg-gray-300" />
-          <p className="my-3 font-semibold">기타</p>
+          {/* <p className="my-3 font-semibold">기타</p>
           <div className="mb-4 flex flex-col gap-4">
             <Button
               radius="sm"
-              href="http://pf.kakao.com/_AxisJG/chat"
+              href="https://pf.kakao.com/_AxisJG"
               target="_blank"
               as={Link}
               startContent={<KakaoChannelImg />}
@@ -155,7 +155,7 @@ const MyPage = () => {
             >
               카카오톡 채널 문의하기
             </Button>
-          </div>
+          </div> */}
           {user.role === 'ADMIN' && (
             <div className="absolute bottom-16 right-4">
               <Button

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import Script from 'next/script';
+import { GTM_ID, pageview } from '../lib/gtm';
+
+const Analytics = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (pathname) {
+      pageview(pathname);
+    }
+  }, [pathname, searchParams]);
+
+  return (
+    <>
+      <noscript>
+        <iframe
+          title="google-analytics"
+          src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+          height="0"
+          width="0"
+          style={{ display: 'none', visibility: 'hidden' }}
+        />
+      </noscript>
+      <Script
+        id="gtm-script"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer', '${GTM_ID}');
+  `,
+        }}
+      />
+    </>
+  );
+};
+
+export default Analytics;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import '@/styles/globals.css';
 import Script from 'next/script';
 import { usePathname } from 'next/navigation';
@@ -12,6 +12,7 @@ import useLocationStore from '@/store/userLocationStore';
 import Header from './components/header/Header';
 import Footer from './components/Footer';
 import Providers from './components/Providers';
+import Analytics from './components/Analytics';
 
 const queryClient = new QueryClient();
 
@@ -56,6 +57,9 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       <body>
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools />
+          <Suspense>
+            <Analytics />
+          </Suspense>
           <Providers>
             {withoutHeader ? null : <Header />}
             <main>{children}</main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -70,6 +70,12 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
           strategy="beforeInteractive"
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_MAP_KEY}&autoload=false&libraries=services,clusterer`}
         />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+          name="description"
+          content="농구를 할 장소와 함께 할 친구를 찾을 수 있는 플랫폼"
+        />
+        <meta name="author" content="Slam Talk" />
       </head>
       <body>
         <QueryClientProvider client={queryClient}>

--- a/src/app/lib/gtm.ts
+++ b/src/app/lib/gtm.ts
@@ -1,6 +1,6 @@
-type WindowWithDataLayer = Window & {
+interface WindowWithDataLayer extends Window {
   dataLayer: Record<string, any>[];
-};
+}
 
 declare const window: WindowWithDataLayer;
 

--- a/src/app/lib/gtm.ts
+++ b/src/app/lib/gtm.ts
@@ -1,0 +1,21 @@
+type WindowWithDataLayer = Window & {
+  dataLayer: Record<string, any>[];
+};
+
+declare const window: WindowWithDataLayer;
+
+export const GTM_ID = process.env.NEXT_PUBLIC_GTM;
+
+export const pageview = (url: string) => {
+  if (typeof window.dataLayer !== 'undefined') {
+    window.dataLayer.push({
+      event: 'pageview',
+      page: url,
+    });
+  } else {
+    console.log({
+      event: 'pageview',
+      page: url,
+    });
+  }
+};


### PR DESCRIPTION
## 📝 작업 내용

> 실사용자 테스트시 **웹사이트 분석 도구가 필요**해보여 **google analytics 계정 생성 후 연결**하는 코드 추가했습니다. 진행하며 **layout 리팩토링**하였습니다. 확인해주시면 잘 반영되었는지 확인을 위해 main으로도 바로 반영해보겠습니다.

- [x] google analytics 연결
- [x] layout 리팩토링 - 변수명 더 명확히 변경, 함수 분리
- [x] meta tag 추가
- [x] (카카오톡 채널 연결 임시 주석 처리)

## 💬 리뷰 요구사항
⭐ **참고자료**
> [google analytics 연결]
    https://manbedded.tistory.com/25
   
> [next.js 환경 google analytics 설정]
⭐ app router 환경: https://dev.to/valse/how-to-setup-google-tag-manager-in-a-next-13-app-router-website-248p
    https://velog.io/@sumi-0011/Next.js-GA
    
  >  [SEO를 위한 meta tag 설정]
  >  meta tag: https://ahrefs.com/blog/seo-meta-tags/
    keywords -> 더이상 잘 사용하지 않음:  https://stackoverflow.com/questions/9110766/what-meta-tag-should-i-use-to-indicate-the-website-not-content-author
    author -> business name 사용: https://stackoverflow.com/questions/9110766/what-meta-tag-should-i-use-to-indicate-the-website-not-content-author

> React 17버전 이후로 `Import React from 'react';` 없이도 문제없이 코드를 작성할 수 있는데 굳이 이 부분을 오류로 판단하는 eslint 규칙이 필요없다고 판단되어 규칙에 "react/react-in-jsx-scope": "off" 설정해주었습니다. 참고: https://mdpapa.tistory.com/164