### PR TITLE
#306 '/user info' 페이지 double click 버그 수정

### DIFF
--- a/src/app/(auth)/user-info/components/UserPosition.tsx
+++ b/src/app/(auth)/user-info/components/UserPosition.tsx
@@ -23,7 +23,7 @@ const UserPosition: React.FC<UserPositionProps> = ({ onPositionSelect }) => {
             key={position.value}
             size="lg"
             radius="full"
-            className="bg-gradient-to-tr from-primary to-secondary text-xl font-semibold text-white shadow-lg dark:shadow-gray-600"
+            className="bg-gradient-to-tr from-primary to-secondary text-xl font-semibold text-white shadow-md dark:shadow-gray-600"
             onClick={() => handlePositionSelect(position.value)}
           >
             {position.value}

--- a/src/app/(auth)/user-info/components/UserSkill.tsx
+++ b/src/app/(auth)/user-info/components/UserSkill.tsx
@@ -24,7 +24,7 @@ const UserSkill: React.FC<UserSkillProps> = ({ onSkillSelect }) => {
             key={skill.value}
             size="lg"
             radius="full"
-            className="bg-gradient-to-tr from-primary to-secondary text-xl font-semibold text-white shadow-lg dark:shadow-gray-600"
+            className="bg-gradient-to-tr from-primary to-secondary text-xl font-semibold text-white shadow-md dark:shadow-gray-600"
             onClick={() => handleSkillSelect(skill.value)}
           >
             {skill.value}

--- a/src/app/(auth)/user-info/page.tsx
+++ b/src/app/(auth)/user-info/page.tsx
@@ -45,17 +45,13 @@ const SignUpProcess = () => {
   const handleSkillSelect = (skill: string) => {
     const updatedSkill = mapSkillToKey(skill);
     setSelectedSkill(updatedSkill);
-    if (selectedSkill !== null) {
-      goToNextStep();
-    }
+    goToNextStep();
   };
 
   const handlePositionSelect = (position: string) => {
     const updatedPosition = mapPositionToKey(position);
     setSelectedPosition(updatedPosition);
-    if (selectedPosition !== null) {
-      goToNextStep();
-    }
+    goToNextStep();
   };
 
   return (


### PR DESCRIPTION
## 📝 작업 내용

> 더블 클릭을 해야 조건부 렌더링이 작동하는 버그 useState가 비동기로 작동한다는 점을 배우고 해당 버그 수정 완료했습니다.

이전 코드
```typescript
const handleSkillSelect = (skill: string) => {
    const updatedSkill = mapSkillToKey(skill);
    setSelectedSkill(updatedSkill);
    if (selectedSkill !== null) {
      goToNextStep();
    }
};

const handlePositionSelect = (position: string) => {
    const updatedPosition = mapPositionToKey(position);
    setSelectedPosition(updatedPosition);
    if (selectedPosition !== null) {
      goToNextStep();
    }
};

```

수정 코드
```typescript
const handleSkillSelect = (skill: string) => {
    const updatedSkill = mapSkillToKey(skill);
    setSelectedSkill(updatedSkill);
    goToNextStep(); // 상태 업데이트 후 바로 다음 단계로 이동
};

const handlePositionSelect = (position: string) => {
    const updatedPosition = mapPositionToKey(position);
    setSelectedPosition(updatedPosition);
    goToNextStep(); // 상태 업데이트 후 바로 다음 단계로 이동
};
```

- **useState는 상태 업데이트 함수가 호출되면 해당 상태가 즉시 업데이트 되지 않고,  비동기적으로 일어나며 다음 렌더링 사이클에서 상태가 적용됩니다.**
- 위와 같은 이유로 상태 업데이트가 다음 렌더링 사이클에 일어나 바로 반영이 안되므로 null을 체크하는 조건문을 빼서 버그 해결 완료했습니다.