### PR TITLE
#309 팀, 메이트 디테일 페이지에서 '지도 보기' 클릭시 해당 주소로 바로 이동 기능 추가

### DIFF
--- a/src/app/admin/components/AdminCourtDetails.tsx
+++ b/src/app/admin/components/AdminCourtDetails.tsx
@@ -155,10 +155,10 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                   길찾기
                 </Button>
               </div>
-              <div className="flex justify-center " />
+              <div className="flex justify-center" />
               <hr className="w-90 my-4 h-px bg-gray-300" />
               <div className="my-4 flex flex-col gap-4">
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLocationDot
                     size={16}
                     className="dark:text-gray-20 text-gray-400"
@@ -168,7 +168,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                     <span className="text-blue-500">복사</span>
                   </button>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaClock
                     size={14}
                     className="text-gray-400 dark:text-gray-200"
@@ -180,7 +180,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                     </span>
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaPhoneAlt
                     size={15}
                     className="pointer-events-auto text-gray-400 dark:text-gray-200"
@@ -189,14 +189,14 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                     {selectedPlace.phoneNum ? selectedPlace.phoneNum : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FeeIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-info text-blue-500">
                     이용료: {selectedPlace.fee}
                   </span>
                 </div>
 
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <WebsiteIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-blue-500">
                     {selectedPlace.website ? (
@@ -208,35 +208,35 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                     )}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 종류:{' '}
                     {selectedPlace.courtType ? selectedPlace.courtType : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 사이즈:{' '}
                     {selectedPlace.courtSize ? selectedPlace.courtSize : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <HoopIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     골대 수:{' '}
                     {selectedPlace.hoopCount ? selectedPlace.hoopCount : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLightbulb
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
                   />
                   <span>야간 조명: {selectedPlace.nightLighting}</span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaParking
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -244,7 +244,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                   <span>주차: {selectedPlace.parkingAvailable}</span>
                 </div>
 
-                <div className="flex gap-2 align-middle text-sm">
+                <div className="flex items-center gap-2 align-middle text-sm">
                   <FaTag
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -265,7 +265,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                       : '-'}
                   </ul>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <InfoIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-sm">
                     {selectedPlace.additionalInfo

--- a/src/app/map/components/CourtDetails.tsx
+++ b/src/app/map/components/CourtDetails.tsx
@@ -195,7 +195,7 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
               <div className="flex justify-center " />
               <hr className="w-90 my-4 h-px bg-gray-300" />
               <div className="my-4 flex flex-col gap-4">
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLocationDot
                     size={16}
                     className="dark:text-gray-20 text-gray-400"
@@ -205,7 +205,7 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                     <span className="text-blue-500">복사</span>
                   </button>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaClock
                     size={14}
                     className="text-gray-400 dark:text-gray-200"
@@ -217,7 +217,7 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                     </span>
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaPhoneAlt
                     size={15}
                     className="pointer-events-auto text-gray-400 dark:text-gray-200"
@@ -227,14 +227,14 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                     {selectedPlace.phoneNum ? selectedPlace.phoneNum : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FeeIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-info text-blue-500">
                     이용료: {selectedPlace.fee}
                   </span>
                 </div>
 
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <WebsiteIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-blue-500">
                     {selectedPlace.website ? (
@@ -246,32 +246,32 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                     )}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 종류: {selectedPlace.courtType}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 사이즈: {selectedPlace.courtSize}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <HoopIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     골대 수: {selectedPlace.hoopCount}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLightbulb
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
                   />
                   <span>야간 조명: {selectedPlace.nightLighting}</span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaParking
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -279,7 +279,7 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                   <span>주차: {selectedPlace.parkingAvailable}</span>
                 </div>
 
-                <div className="flex gap-2 align-middle text-sm">
+                <div className="flex items-center gap-2 align-middle text-sm">
                   <FaTag
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -302,7 +302,7 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                       )}
                   </ul>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <InfoIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-sm">
                     {selectedPlace.additionalInfo

--- a/src/app/map/components/CourtDetailsFull.tsx
+++ b/src/app/map/components/CourtDetailsFull.tsx
@@ -145,7 +145,7 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
               </div>
               <hr className="w-90 my-4 h-px bg-gray-300" />
               <div className="my-4 flex flex-col gap-4">
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLocationDot
                     size={16}
                     className="dark:text-gray-20 text-gray-400"
@@ -155,7 +155,7 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                     <span className="text-blue-500">복사</span>
                   </button>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaClock
                     size={14}
                     className="text-gray-400 dark:text-gray-200"
@@ -167,7 +167,7 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                     </span>
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaPhoneAlt
                     size={15}
                     className="pointer-events-auto text-gray-400 dark:text-gray-200"
@@ -177,14 +177,14 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                     {selectedPlace.phoneNum ? selectedPlace.phoneNum : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FeeIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-info text-blue-500">
                     이용료: {selectedPlace.fee}
                   </span>
                 </div>
 
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <WebsiteIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-blue-500">
                     {selectedPlace.website ? (
@@ -196,32 +196,32 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                     )}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 종류: {selectedPlace.courtType}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 사이즈: {selectedPlace.courtSize}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <HoopIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     골대 수: {selectedPlace.hoopCount}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLightbulb
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
                   />
                   <span>야간 조명: {selectedPlace.nightLighting}</span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaParking
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -229,7 +229,7 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                   <span>주차: {selectedPlace.parkingAvailable}</span>
                 </div>
 
-                <div className="flex gap-2 align-middle text-sm">
+                <div className="flex items-center gap-2 align-middle text-sm">
                   <FaTag
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -252,7 +252,7 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                       )}
                   </ul>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <InfoIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-sm">
                     {selectedPlace.additionalInfo

--- a/src/app/map/components/CourtReportDetails.tsx
+++ b/src/app/map/components/CourtReportDetails.tsx
@@ -113,7 +113,7 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
               <div className="flex justify-center " />
               <hr className="w-90 my-4 h-px bg-gray-300" />
               <div className="my-4 flex flex-col gap-4">
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLocationDot
                     size={16}
                     className="dark:text-gray-20 text-gray-400"
@@ -123,7 +123,7 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                     <span className="text-blue-500">복사</span>
                   </button>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaClock
                     size={14}
                     className="text-gray-400 dark:text-gray-200"
@@ -135,7 +135,7 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                     </span>
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaPhoneAlt
                     size={15}
                     className="pointer-events-auto text-gray-400 dark:text-gray-200"
@@ -144,14 +144,14 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                     {selectedPlace.phoneNum ? selectedPlace.phoneNum : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FeeIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-info text-blue-500">
                     이용료: {selectedPlace.fee}
                   </span>
                 </div>
 
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <WebsiteIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-blue-500">
                     {selectedPlace.website ? (
@@ -163,35 +163,35 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                     )}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 종류:{' '}
                     {selectedPlace.courtType ? selectedPlace.courtType : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <CourtIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     코트 사이즈:{' '}
                     {selectedPlace.courtSize ? selectedPlace.courtSize : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <HoopIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="font-medium">
                     골대 수:{' '}
                     {selectedPlace.hoopCount ? selectedPlace.hoopCount : '-'}
                   </span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaLightbulb
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
                   />
                   <span>야간 조명: {selectedPlace.nightLighting}</span>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <FaParking
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -199,7 +199,7 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                   <span>주차: {selectedPlace.parkingAvailable}</span>
                 </div>
 
-                <div className="flex gap-2 align-middle text-sm">
+                <div className="flex items-center gap-2 align-middle text-sm">
                   <FaTag
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
@@ -220,7 +220,7 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                       : '-'}
                   </ul>
                 </div>
-                <div className="flex gap-2 align-middle">
+                <div className="flex items-center gap-2 align-middle">
                   <InfoIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-sm">
                     {selectedPlace.additionalInfo

--- a/src/app/map/components/KakaoMap.tsx
+++ b/src/app/map/components/KakaoMap.tsx
@@ -4,8 +4,8 @@
 
 'use client';
 
-import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   Map,
   MapMarker,
@@ -48,6 +48,8 @@ export interface MouseEventWithLatLng {
 }
 
 const KakaoMap = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [map, setMap] = useState<any>();
   const userLocation = userLocationStore((state) => state.userLocation);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -73,9 +75,7 @@ const KakaoMap = () => {
   } | null>(null);
   const [clickPositionAddress, setClickPositionAddress] = useState<string>('');
   const { isOpen, onOpen, onClose } = useDisclosure();
-
   const isLoggedIn = LocalStorage.getItem('isLoggedIn');
-  const router = useRouter();
 
   const { error, data: courts } = useQuery<BasketballCourts[]>({
     queryKey: ['courts'],
@@ -133,11 +133,6 @@ const KakaoMap = () => {
   const handleSearch = () => {
     if (!map) return;
 
-    if (!searchKeyword) {
-      alert('검색어를 입력하세요.');
-      return;
-    }
-
     const filteredCourts = filterCourts(courts || [], searchKeyword);
     if (filteredCourts.length > 0) {
       const firstCourt = filteredCourts[0];
@@ -174,6 +169,20 @@ const KakaoMap = () => {
       handleSearch();
     }
   };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const searchAddressQueryParams = () => {
+    const address = searchParams.get('address');
+    if (address) {
+      setSearchKeyword(address);
+      handleSearch();
+      router.replace('/map');
+    }
+  };
+
+  useEffect(() => {
+    searchAddressQueryParams();
+  }, [searchAddressQueryParams]);
 
   const handleClickReport = (
     _: kakao.maps.Map,

--- a/src/app/matching/mate-details/[postId]/page.tsx
+++ b/src/app/matching/mate-details/[postId]/page.tsx
@@ -246,7 +246,7 @@ const MateDetailsPage = () => {
             </Snippet>
           </div>
 
-          <Link href="/map">
+          <Link href={`/map?address=${data.locationDetail}`}>
             <div className="pr-10 text-blue-600 hover:underline">지도 보기</div>
           </Link>
         </div>

--- a/src/app/matching/team-details/[postId]/page.tsx
+++ b/src/app/matching/team-details/[postId]/page.tsx
@@ -258,7 +258,7 @@ const TeamDetailsPage = () => {
             </Snippet>
           </div>
 
-          <Link href="/map">
+          <Link href={`/map?address=${data.locationDetail}`}>
             <div className="pr-10 text-blue-600 hover:underline">지도 보기</div>
           </Link>
         </div>


### PR DESCRIPTION
## 📝 작업 내용

> 팀, 메이트 디테일 페이지에서 '지도 보기' 클릭시 해당 주소로 바로 이동 기능 추가

### 스크린샷
<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/2cdb8d1d-f3f1-444e-b45d-454a8bbf94c3" width="40%"/>
해당 위치로 바로 이동 ->
<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/2e030aa2-6a3d-41ff-971d-05081db66402" width="40%"/>


이동 완료 후에는 /map 으로 url 다시 바꿔주어 이후 지도 이동 동작에 영향가지 않도록 했습니다. '?address=' 쿼리를 넣으면 항상 검색어에 자동으로 들어가게 구현했습니다.

## 💬 리뷰 요구사항
- 👀 같이 리뷰 필요

> 추후 메이트, 팀 매칭 작성 페이지에 주소 검색 부분에 지도가 뜨기 전 로딩도 넣으면 좋을 것 같습니다.