### PR TITLE
#326 공식 이메일 기입, 탈퇴 메시지 수정

### DIFF
--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -18,12 +18,12 @@ const Loginlayout = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <div className="md:h-100 sm:h-100 relative h-full w-full">
+    <div className="relative h-full w-full overflow-y-auto overflow-x-hidden">
       <div
         aria-label="뒤로가기"
         role="link"
         tabIndex={0}
-        className="absolute left-4 top-0"
+        className="absolute left-4 top-4"
         onClick={handleGoBack}
         onKeyDown={handleKeyDown}
       >
@@ -31,6 +31,14 @@ const Loginlayout = ({ children }: { children: React.ReactNode }) => {
       </div>
       <h2 className="mt-4 text-center text-lg font-semibold">로그인</h2>
       <main>{children}</main>
+      <footer className="sticky bottom-12 mt-72 flex w-full max-w-[600px] flex-col justify-center gap-2 bg-gray-100 px-4 pb-3 pt-8 text-xs text-gray-500">
+        <p className="text-sm">슬램톡 정보</p>
+        <a href="mailto:slamtalk.official@gmail.com">
+          <p>문의: slamtalk.official@gmail.com</p>
+        </a>
+        <hr className="my-3 h-px w-full bg-gray-300" />
+        <p className="text-gray-400">©Slam Talk. All rights reserved.</p>
+      </footer>
     </div>
   );
 };

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -91,4 +91,5 @@ const Login = () => {
     </>
   );
 };
+
 export default Login;

--- a/src/app/(auth)/my-page/page.tsx
+++ b/src/app/(auth)/my-page/page.tsx
@@ -17,6 +17,7 @@ import {
   ModalBody,
   ModalFooter,
   useDisclosure,
+  Tooltip,
 } from '@nextui-org/react';
 import Link from 'next/link';
 import LocalStorage from '@/utils/localstorage';
@@ -160,6 +161,18 @@ const MyPage = () => {
               카카오톡 채널 문의하기
             </Button>
           </div> */}
+          <div>
+            <p className="mb-3 font-semibold">문의</p>
+            <Tooltip
+              showArrow
+              content="slamtalk.official@gmail.com"
+              placement="right-end"
+            >
+              <a href="mailto:slamtalk.official@gmail.com">
+                <span>📬 이메일 문의</span>
+              </a>
+            </Tooltip>
+          </div>
           {user.role === 'ADMIN' && (
             <div className="absolute bottom-16 right-4">
               <Button

--- a/src/app/(auth)/my-page/settings/page.tsx
+++ b/src/app/(auth)/my-page/settings/page.tsx
@@ -160,10 +160,7 @@ const MyPageSettings = () => {
               <>
                 <ModalHeader className="flex flex-col gap-1">탈퇴</ModalHeader>
                 <ModalBody>
-                  <p>
-                    정말 탈퇴하시겠습니까? 탈퇴 후 7일 동안 같은 이메일로
-                    재가입이 불가하고 복구가 어렵습니다.
-                  </p>
+                  <p>정말 탈퇴하시겠습니까? 탈퇴하시면 복구가 어렵습니다.</p>
                 </ModalBody>
                 <ModalFooter>
                   <Button

--- a/src/app/(auth)/social-login/page.tsx
+++ b/src/app/(auth)/social-login/page.tsx
@@ -40,11 +40,6 @@ const SocialLogin = () => {
         }
       }
     });
-  } else if (login === 'false') {
-    alert(
-      '탈퇴한 유저입니다. 같은 계정으로 로그인을 원하시면 탈퇴 7일 이후에 재가입 해주세요.'
-    );
-    router.push('/login');
   }
   return null;
 };


### PR DESCRIPTION
## 📝 작업 내용

> 탈퇴 후 7일간 가입 못하는 백엔드 로직이 구현이 안되면서 관련 메시지 삭제했습니다.
> 문의 받을 수 있는 공식 이메일 로그인 페이지 하단과 마이페이지에 추가 완료 했습니다.

- [x] 공식 이메일 기입 - 문의, 푸터 작성
- [x] 탈퇴 메시지 수정

### 스크린샷
<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/18299eda-1427-42a8-8de1-97f524da462d" width="40%">

> 그냥 작성하면 잘려 보여서 지그재그 참고해서 스크롤 내리면 보이도록 해놨습니다.

<img src="https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/8a247c19-8252-427a-9538-eb1460caab6b" width="40%">

## 💬 리뷰 요구사항
- 👀 같이 리뷰 필요