### PR TITLE
#343 백엔드 리팩토링에 따른 농구장 제보 관련 타입 수정, 관리자 페이지 스타일링 수정, 농구장 제보 데이터 수정 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@
 
 <br/>
 
+<li>자체 회원가입 및 소셜 로그인 개발</li>
 <li>농구장 지도, 제보 기능 개발</li>
-<li>회원가입 및 로그인 개발</li>
+<li>관리자 페이지 - 제보 정보 관리</li>
 <li>마이페이지 및 유저 관리 기능 개발(프로필 표시 및 수정, 탈퇴, 비밀번호 재설정 등)</li>
 <li>인앱 알림 기능 개발</li>
 <li>개발 전반 환경설정(Next.js, GitHub Actions, 테마 등)</li>
@@ -167,7 +168,7 @@
 
 | [🔗 커뮤니티](https://github.com/SlamTalk/slam-talk-frontend/wiki/%EC%A3%BC%EC%9A%94-%EA%B8%B0%EB%8A%A5-%EC%86%8C%EA%B0%9C#-%EC%BB%A4%EB%AE%A4%EB%8B%88%ED%8B%B0) | [🔗 1:1 채팅](https://github.com/SlamTalk/slam-talk-frontend/wiki/%EC%A3%BC%EC%9A%94-%EA%B8%B0%EB%8A%A5-%EC%86%8C%EA%B0%9C#-11-%EC%B1%84%ED%8C%85) | [🔗 농구장 시설 채팅](https://github.com/SlamTalk/slam-talk-frontend/wiki/%EC%A3%BC%EC%9A%94-%EA%B8%B0%EB%8A%A5-%EC%86%8C%EA%B0%9C#-%EB%86%8D%EA%B5%AC%EC%9E%A5-%EC%8B%9C%EC%84%A4-%EC%B1%84%ED%8C%85) | [🔗 관리자 페이지](https://github.com/SlamTalk/slam-talk-frontend/wiki/%EC%A3%BC%EC%9A%94-%EA%B8%B0%EB%8A%A5-%EC%86%8C%EA%B0%9C#-%EA%B4%80%EB%A6%AC%EC%9E%90-%ED%8E%98%EC%9D%B4%EC%A7%80) |
 | :---------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|                    <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/76f50d21-a2b1-4727-8b9f-e851d45c6bfa'>                    |            <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/6ebb2284-a133-4343-b6f1-81af871f6e78'>             |                                      <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/35abce74-7444-466e-ab93-1cfe24d6f841'>                                       |                               <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/100774811/a3e09059-c57a-47a1-af85-42fc66c5647f'>                                |
+|                    <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/76f50d21-a2b1-4727-8b9f-e851d45c6bfa'>                    |            <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/6ebb2284-a133-4343-b6f1-81af871f6e78'>             |                                      <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/92986844/35abce74-7444-466e-ab93-1cfe24d6f841'>                                       |                               <img width='400' src='https://github.com/SlamTalk/slam-talk-frontend/assets/103404125/8c83dbe2-8143-4fbf-a799-0cc9158b27a9'>                                |
 
 ## 🕹 프로젝트 구동 방식
 
@@ -210,3 +211,5 @@ npm run dev
 ## 기타
 
 - 구름 풀스택 2회차 최종 프로젝트 인기상 수상 - [발표(24/02/22) PPT](https://github.com/SlamTalk/slam-talk-frontend/files/14399752/slam_talk.pdf)
+
+---

--- a/src/app/admin/components/AdminCourtDetails.tsx
+++ b/src/app/admin/components/AdminCourtDetails.tsx
@@ -82,8 +82,8 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
     return (
       <>
         <title>슬램톡 | 관리자</title>
-        <div className="min-w-md sm-h-full absolute inset-0 z-40 m-auto h-fit max-h-[calc(100vh-109px)] w-fit min-w-96 max-w-md overflow-y-auto rounded-lg bg-background shadow-md transition-all duration-300 ease-in-out sm:min-w-full">
-          <div className="w-full text-sm">
+        <div className="min-w-md sm-h-full fixed inset-0 z-40 m-auto h-fit max-h-[calc(100vh-109px)] w-fit min-w-96 max-w-md overflow-y-auto rounded-lg bg-background shadow-md transition-all duration-300 ease-in-out sm:min-w-full">
+          <div className="relative h-full w-full text-sm">
             <div className="relative h-56 w-full sm:h-52">
               <Image
                 fill
@@ -240,15 +240,17 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                   />
                   <ul className="flex gap-2">
                     {data.convenience?.length
-                      ? data.convenience.map((tag: string, idx: number) => (
-                          <li
-                            // eslint-disable-next-line react/no-array-index-key
-                            key={idx}
-                            className="rounded-sm bg-gray-100 px-1 text-gray-500 dark:bg-gray-300 dark:text-gray-600"
-                          >
-                            <span>{tag}</span>
-                          </li>
-                        ))
+                      ? data.convenience
+                          .filter((item) => item !== '')
+                          .map((tag: string, idx: number) => (
+                            <li
+                              // eslint-disable-next-line react/no-array-index-key
+                              key={idx}
+                              className="rounded-sm bg-gray-100 px-1 text-gray-500 dark:bg-gray-300 dark:text-gray-600"
+                            >
+                              <span>{tag}</span>
+                            </li>
+                          ))
                       : '-'}
                   </ul>
                 </div>

--- a/src/app/admin/components/AdminCourtDetails.tsx
+++ b/src/app/admin/components/AdminCourtDetails.tsx
@@ -50,7 +50,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
   };
 
   const handleAccept = async () => {
-    const cleanedData = convertCourtData(data);
+    const cleanedData = convertCourtData(data, data.photoUrl);
 
     try {
       const response = await axiosInstance.put(

--- a/src/app/admin/components/AdminCourtDetails.tsx
+++ b/src/app/admin/components/AdminCourtDetails.tsx
@@ -3,7 +3,13 @@
 import React from 'react';
 import { Button } from '@nextui-org/react';
 import { IoIosClose } from 'react-icons/io';
-import { FaPhoneAlt, FaParking, FaTag, FaRegDotCircle } from 'react-icons/fa';
+import {
+  FaPhoneAlt,
+  FaParking,
+  FaTag,
+  FaRegDotCircle,
+  FaEdit,
+} from 'react-icons/fa';
 import Image from 'next/image';
 import { FaLocationDot, FaClock, FaLightbulb } from 'react-icons/fa6';
 import Link from 'next/link';
@@ -18,13 +24,15 @@ import { convertCourtData } from '@/utils/convertCourtData';
 
 interface CourtDetailsProps {
   data: BasketballCourtReportAdmin;
-  onClose: () => void;
+  handleCloseDetails: () => void;
+  handleEditMode: () => void;
   refetch: () => void;
 }
 
 const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
   data,
-  onClose,
+  handleCloseDetails,
+  handleEditMode,
   refetch,
 }) => {
   const handleReject = async () => {
@@ -34,7 +42,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
       );
       if (response.status === 200) {
         refetch();
-        onClose();
+        handleCloseDetails();
       }
     } catch (error) {
       console.error('농구장 거절 에러:', error);
@@ -51,7 +59,7 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
       );
       if (response.status === 200) {
         refetch();
-        onClose();
+        handleCloseDetails();
       }
     } catch (error) {
       console.error('농구장 수락 에러:', error);
@@ -90,27 +98,30 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                 variant="light"
                 isIconOnly
                 className="absolute right-2 top-2"
-                onClick={onClose}
+                onClick={handleCloseDetails}
                 aria-label="Close"
               >
                 <IoIosClose size={30} />
               </Button>
             </div>
             <div className="p-4">
-              <h2 className="mb-1 text-xl font-bold">{data.courtName}</h2>
+              <div className="flex items-center justify-between gap-2">
+                <h2 className="mb-1 text-xl font-bold">{data.courtName}</h2>
+                <Button
+                  startContent={<FaEdit size={20} />}
+                  className="flex items-center justify-center gap-1"
+                  onClick={handleEditMode}
+                >
+                  수정하기
+                </Button>
+              </div>
+
               {data.indoorOutdoor && (
                 <span className="break-keep rounded-sm bg-gray-100 px-1 text-gray-500 dark:bg-gray-300 dark:text-gray-600">
                   {data.indoorOutdoor}
                 </span>
               )}
-              <div className="justify-end gap-2">
-                <Button color="danger" variant="light" onClick={handleReject}>
-                  거절
-                </Button>
-                <Button color="primary" onClick={handleAccept}>
-                  승인
-                </Button>
-              </div>
+
               <div className="flex w-full items-center justify-end">
                 <Button
                   size="sm"
@@ -249,6 +260,14 @@ const AdminCourtDetails: React.FC<CourtDetailsProps> = ({
                 </div>
               </div>
             </div>
+          </div>
+          <div className="flex justify-center gap-2 p-4 pt-0">
+            <Button color="danger" variant="flat" onClick={handleReject}>
+              거절
+            </Button>
+            <Button color="primary" onClick={handleAccept}>
+              승인
+            </Button>
           </div>
         </div>
       </>

--- a/src/app/admin/components/EditAdminCourtDetails.tsx
+++ b/src/app/admin/components/EditAdminCourtDetails.tsx
@@ -21,7 +21,6 @@ import {
   useDisclosure,
 } from '@nextui-org/react';
 import { IoIosClose } from 'react-icons/io';
-import { FaTrashCan } from 'react-icons/fa6';
 import axiosInstance from '@/app/api/axiosInstance';
 import { BasketballCourtReportAdmin } from '@/types/basketballCourt/basketballCourtReport';
 import { convertCourtData } from '@/utils/convertCourtData';
@@ -69,15 +68,6 @@ const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
         setPreviewUrl(imageUrl);
       }
     }
-  };
-
-  const resetPreview = () => {
-    setFile(null);
-    setPreviewUrl(null);
-  };
-
-  const handleFileDelete = () => {
-    resetPreview();
   };
 
   const onSubmit: SubmitHandler<BasketballCourtReportAdmin> = async (data) => {
@@ -178,23 +168,11 @@ const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
                   onChange={handleFileChange}
                 />
                 {previewUrl && (
-                  <>
-                    <Button
-                      size="sm"
-                      radius="full"
-                      aria-label="삭제"
-                      startContent={<FaTrashCan size={16} />}
-                      className="absolute bottom-2 right-2 z-30 gap-1 bg-gray-400 p-1 font-bold text-white"
-                      onClick={handleFileDelete}
-                    >
-                      삭제
-                    </Button>
-                    <img
-                      src={previewUrl}
-                      alt="미리보기"
-                      className="absolute inset-0 h-full w-full object-cover"
-                    />
-                  </>
+                  <img
+                    src={previewUrl}
+                    alt="미리보기"
+                    className="absolute inset-0 h-full w-full object-cover"
+                  />
                 )}
               </div>
               <div className="mt-2 flex flex-col p-4">

--- a/src/app/admin/components/EditAdminCourtDetails.tsx
+++ b/src/app/admin/components/EditAdminCourtDetails.tsx
@@ -129,7 +129,7 @@ const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
           <div className="relative h-full overflow-y-auto">
             <div className="sticky top-0 z-30 flex h-14 w-full items-center justify-center border-b bg-background">
               <p className="text-center text-xl font-semibold">
-                농구장 제보하기
+                농구장 제보 데이터 수정하기
               </p>
               <Button
                 size="sm"

--- a/src/app/admin/components/EditAdminCourtDetails.tsx
+++ b/src/app/admin/components/EditAdminCourtDetails.tsx
@@ -1,0 +1,515 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable no-useless-escape */
+
+'use client';
+
+import React, { useState } from 'react';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import {
+  Textarea,
+  Input,
+  Select,
+  RadioGroup,
+  Radio,
+  SelectItem,
+  Button,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+} from '@nextui-org/react';
+import { IoIosClose } from 'react-icons/io';
+import { FaTrashCan } from 'react-icons/fa6';
+import axiosInstance from '@/app/api/axiosInstance';
+import { BasketballCourtReportAdmin } from '@/types/basketballCourt/basketballCourtReport';
+import { convertCourtData } from '@/utils/convertCourtData';
+import { CameraIcon } from '@/app/map/components/icons/CameraIcon';
+import { ErrorMessage } from '@hookform/error-message';
+import {
+  basketballConvenience,
+  basketballCourtSize,
+  basketballCourtType,
+} from '@/constants/courtReportData';
+
+interface EditAdminCourtDetailsProps {
+  data: BasketballCourtReportAdmin;
+  handleEditClose: () => void;
+}
+
+const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
+  data,
+  handleEditClose,
+}) => {
+  const { isOpen, onOpen } = useDisclosure();
+  const [editSuccess, setEditSuccess] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(data.photoUrl);
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BasketballCourtReportAdmin>({
+    defaultValues: data,
+  });
+
+  const MAX_FILE_SIZE_MB = 1;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files && e.target.files[0];
+    if (selectedFile) {
+      if (selectedFile.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+        alert(`파일 크기는 ${MAX_FILE_SIZE_MB}MB를 초과할 수 없습니다.`);
+        e.target.value = '';
+      } else {
+        setFile(selectedFile);
+        const imageUrl = URL.createObjectURL(selectedFile);
+        setPreviewUrl(imageUrl);
+      }
+    }
+  };
+
+  const resetPreview = () => {
+    setFile(null);
+    setPreviewUrl(null);
+  };
+
+  const handleFileDelete = () => {
+    resetPreview();
+  };
+
+  const onSubmit: SubmitHandler<BasketballCourtReportAdmin> = async (data) => {
+    const formData = new FormData();
+
+    if (file) {
+      formData.append('image', file);
+    }
+
+    const finalData = convertCourtData(data);
+
+    formData.append(
+      'data',
+      new Blob([JSON.stringify(finalData)], {
+        type: 'application/json',
+      })
+    );
+
+    try {
+      const response = await axiosInstance.patch(
+        `/api/map/report/edit/${data.courtId}`,
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        setEditSuccess(true);
+        onOpen();
+      }
+    } catch (error) {
+      setEditSuccess(false);
+      onOpen();
+    }
+  };
+
+  if (data) {
+    return (
+      <>
+        <title>슬램톡 | 관리자</title>
+        <div
+          className={`absolute inset-0 z-20 m-auto w-full max-w-md overflow-y-auto rounded-lg
+    bg-background text-sm shadow-md transition-all duration-300 ease-in-out
+    md:max-h-[90vh] md:text-lg lg:text-xl`}
+        >
+          <div className="relative h-full overflow-y-auto">
+            <div className="sticky top-0 z-30 flex h-14 w-full items-center justify-center border-b bg-background">
+              <p className="text-center text-xl font-semibold">
+                농구장 제보하기
+              </p>
+              <Button
+                size="sm"
+                radius="full"
+                variant="light"
+                isIconOnly
+                className="absolute right-2 top-2"
+                onClick={handleEditClose}
+                aria-label="Close"
+              >
+                <IoIosClose size={30} />
+              </Button>
+            </div>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <div className="relative flex h-52 w-full items-center justify-center bg-gray-200 dark:bg-gray-800">
+                <div className="absolute top-0 z-10 flex h-8 w-full items-center justify-center bg-yellow-200 px-4 font-semibold">
+                  <p className="text-sm text-black sm:text-xs">
+                    농구장 정보를 정확하게 확인하고 제보 데이터 수정 후
+                    수락해주세요.
+                  </p>
+                </div>
+                <div>
+                  <Button
+                    className="z-10 mt-2"
+                    color="primary"
+                    radius="full"
+                    startContent={
+                      // eslint-disable-next-line jsx-a11y/label-has-associated-control
+                      <label htmlFor="fileInput">
+                        <CameraIcon />
+                      </label>
+                    }
+                  >
+                    <label htmlFor="fileInput">
+                      <span className="font-medium">
+                        {file || previewUrl ? '사진 변경' : '사진 추가'}
+                      </span>
+                    </label>
+                  </Button>
+                </div>
+                <input
+                  className="hidden"
+                  id="fileInput"
+                  type="file"
+                  accept="image/png, image/jpg, image/jpeg"
+                  onChange={handleFileChange}
+                />
+                {previewUrl && (
+                  <>
+                    <Button
+                      size="sm"
+                      radius="full"
+                      aria-label="삭제"
+                      startContent={<FaTrashCan size={16} />}
+                      className="absolute bottom-2 right-2 z-30 gap-1 bg-gray-400 p-1 font-bold text-white"
+                      onClick={handleFileDelete}
+                    >
+                      삭제
+                    </Button>
+                    <img
+                      src={previewUrl}
+                      alt="미리보기"
+                      className="absolute inset-0 h-full w-full object-cover"
+                    />
+                  </>
+                )}
+              </div>
+              <div className="mt-2 flex flex-col p-4">
+                <Input
+                  defaultValue={data.courtName}
+                  className="z-10 font-semibold"
+                  radius="sm"
+                  isRequired
+                  labelPlacement="outside"
+                  variant="bordered"
+                  type="string"
+                  label="농구장명"
+                  placeholder="농구장명을 입력해 주세요."
+                  {...register('courtName', {
+                    required: true,
+                    minLength: {
+                      value: 2,
+                      message:
+                        '농구장 이름을 2자 이상 30자 이하로 입력해 주세요.',
+                    },
+                    maxLength: {
+                      value: 30,
+                      message:
+                        '농구장 이름을 2자 이상 30자 이하로 입력해 주세요.',
+                    },
+                  })}
+                />
+                <div className="flex h-6 items-center">
+                  <ErrorMessage
+                    errors={errors}
+                    name="courtName"
+                    render={({ message }) => (
+                      <p className="text-xs text-danger">{message}</p>
+                    )}
+                  />
+                </div>
+                <div className="w-full text-sm">
+                  <p className="font-semibold">주소</p>
+                  <p>{data.address}</p>
+                </div>
+                <div className="flex gap-4 pt-6 md:flex-nowrap">
+                  <Select
+                    defaultSelectedKeys={data.courtType ? [data.courtType] : []}
+                    className="z-10 max-w-xs font-semibold"
+                    radius="sm"
+                    labelPlacement="outside"
+                    label="코트 종류"
+                    placeholder="코트 종류"
+                    variant="bordered"
+                    {...register('courtType')}
+                  >
+                    {basketballCourtType.map((courtType) => (
+                      <SelectItem key={courtType.value} value={courtType.value}>
+                        {courtType.value}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                  <Select
+                    defaultSelectedKeys={data.courtSize ? [data.courtSize] : []}
+                    className="z-10 max-w-xs font-semibold"
+                    radius="sm"
+                    labelPlacement="outside"
+                    label="코트 사이즈"
+                    placeholder="코트 사이즈"
+                    variant="bordered"
+                    {...register('courtSize')}
+                  >
+                    {basketballCourtSize.map((courtSize) => (
+                      <SelectItem key={courtSize.value} value={courtSize.value}>
+                        {courtSize.value}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                </div>
+                <Input
+                  defaultValue={data.hoopCount ? data.hoopCount.toString() : ''}
+                  className="z-10 pt-6 font-semibold"
+                  radius="sm"
+                  labelPlacement="outside"
+                  variant="bordered"
+                  type="number"
+                  label="골대 수"
+                  placeholder="농구장 골대 수를 입력해 주세요."
+                  {...register('hoopCount', {
+                    min: {
+                      value: 1,
+                      message: '농구장 골대 수를 1개 이상으로 입력해 주세요.',
+                    },
+                    max: {
+                      value: 30,
+                      message: '농구장 골대 수를 30개 이하로 입력해 주세요.',
+                    },
+                  })}
+                />
+                <div className="flex h-6 items-center">
+                  <ErrorMessage
+                    errors={errors}
+                    name="hoopCount"
+                    render={({ message }) => (
+                      <p className="text-xs text-danger">{message}</p>
+                    )}
+                  />
+                </div>
+                <Select
+                  defaultSelectedKeys={data.convenience || []}
+                  className="z-10 font-semibold"
+                  radius="sm"
+                  labelPlacement="outside"
+                  label="편의시설"
+                  placeholder="편의시설"
+                  selectionMode="multiple"
+                  variant="bordered"
+                  {...register('convenience')}
+                >
+                  {basketballConvenience.map((convenience) => (
+                    <SelectItem
+                      key={convenience.value}
+                      value={convenience.value}
+                    >
+                      {convenience.value}
+                    </SelectItem>
+                  ))}
+                </Select>
+                <Input
+                  defaultValue={data.phoneNum || ''}
+                  className="z-10 pt-6 font-semibold sm:pb-2"
+                  radius="sm"
+                  labelPlacement="outside"
+                  variant="bordered"
+                  type="tel"
+                  label="전화번호"
+                  placeholder="대표 전화번호를 입력해 주세요."
+                  {...register('phoneNum', {
+                    pattern: {
+                      value: /^\d{2,3}-?\d{3,4}-?\d{4}$/,
+                      message:
+                        '전화번호 형식으로 입력해 주세요. 00-000-0000 또는 000-0000-0000',
+                    },
+                  })}
+                />
+                <div className="flex h-6 items-center sm:pb-2">
+                  <ErrorMessage
+                    errors={errors}
+                    name="phoneNum"
+                    render={({ message }) => (
+                      <p className="text-xs text-danger">{message}</p>
+                    )}
+                  />
+                </div>
+                <Input
+                  defaultValue={data.website || ''}
+                  className="z-10 text-sm font-semibold"
+                  radius="sm"
+                  labelPlacement="outside"
+                  variant="bordered"
+                  type="url"
+                  label="홈페이지"
+                  placeholder="관련 홈페이지를 입력해 주세요."
+                  {...register('website', {
+                    pattern: {
+                      value:
+                        /(http[s]?|ftp):\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}/g,
+                      message: '홈페이지 링크를 입력해 주세요.',
+                    },
+                  })}
+                />
+                <div className="flex h-6 items-center">
+                  <ErrorMessage
+                    errors={errors}
+                    name="website"
+                    render={({ message }) => (
+                      <p className="text-xs text-danger">{message}</p>
+                    )}
+                  />
+                </div>
+                <div className="flex flex-col gap-4">
+                  <Controller
+                    defaultValue={data.indoorOutdoor}
+                    control={control}
+                    name="indoorOutdoor"
+                    render={({ field: { onChange } }) => (
+                      <RadioGroup
+                        defaultValue={data.indoorOutdoor || ''}
+                        onChange={(value) => onChange(value)}
+                        className="text-sm font-semibold"
+                        label="실내외"
+                        orientation="horizontal"
+                      >
+                        <Radio value="실내">실내</Radio>
+                        <Radio value="야외">야외</Radio>
+                      </RadioGroup>
+                    )}
+                  />
+                  <Controller
+                    defaultValue={data.nightLighting}
+                    control={control}
+                    name="nightLighting"
+                    render={({ field: { onChange } }) => (
+                      <RadioGroup
+                        defaultValue={data.nightLighting || ''}
+                        onChange={(value) => onChange(value)}
+                        className="text-sm font-semibold"
+                        label="야간 조명"
+                        orientation="horizontal"
+                      >
+                        <Radio value="있음">있음</Radio>
+                        <Radio value="없음">없음</Radio>
+                      </RadioGroup>
+                    )}
+                  />
+                  <Controller
+                    defaultValue={data.openingHours}
+                    control={control}
+                    name="openingHours"
+                    render={({ field: { onChange } }) => (
+                      <RadioGroup
+                        defaultValue={data.openingHours || ''}
+                        onChange={(value) => onChange(value)}
+                        className="text-sm font-semibold"
+                        label="개방 시간"
+                        orientation="horizontal"
+                      >
+                        <Radio value="제한">제한</Radio>
+                        <Radio value="24시">24시</Radio>
+                      </RadioGroup>
+                    )}
+                  />
+                  <Controller
+                    defaultValue={data.fee}
+                    control={control}
+                    name="fee"
+                    render={({ field: { onChange } }) => (
+                      <RadioGroup
+                        defaultValue={data.fee || ''}
+                        onChange={(value) => onChange(value)}
+                        className="text-sm font-semibold"
+                        label="사용료"
+                        orientation="horizontal"
+                      >
+                        <Radio value="무료">무료</Radio>
+                        <Radio value="유료">유료</Radio>
+                      </RadioGroup>
+                    )}
+                  />
+                  <Controller
+                    defaultValue={data.parkingAvailable}
+                    control={control}
+                    name="parkingAvailable"
+                    render={({ field: { onChange } }) => (
+                      <RadioGroup
+                        defaultValue={data.parkingAvailable || ''}
+                        onChange={(value) => onChange(value)}
+                        className="text-sm font-semibold"
+                        label="주차 여부"
+                        orientation="horizontal"
+                      >
+                        <Radio value="가능">가능</Radio>
+                        <Radio value="불가능">불가능</Radio>
+                      </RadioGroup>
+                    )}
+                  />
+                </div>
+
+                <div className="mt-6 w-full">
+                  <Textarea
+                    defaultValue={data.additionalInfo || ''}
+                    radius="sm"
+                    maxRows={3}
+                    variant="bordered"
+                    label="기타 정보"
+                    placeholder="해당 농구장에 관한 기타 정보를 입력해 주세요."
+                    {...register('additionalInfo', { maxLength: 300 })}
+                  />
+                </div>
+              </div>
+              <div className="sticky bottom-0 z-30 flex h-14 items-center border-t bg-background px-4">
+                <Button
+                  radius="sm"
+                  aria-label="수정하기"
+                  type="submit"
+                  className="text-md w-full bg-primary font-medium text-white"
+                >
+                  수정하기
+                </Button>
+              </div>
+            </form>
+          </div>
+          <Modal isOpen={isOpen} onClose={handleEditClose} placement="center">
+            <ModalContent>
+              {() => (
+                <>
+                  <ModalHeader className="flex flex-col gap-1">
+                    농구장 제보 데이터 수정
+                  </ModalHeader>
+                  <ModalBody>
+                    {editSuccess ? (
+                      <p>농구장 제보 데이터 수정이 완료되었습니다.</p>
+                    ) : (
+                      <p>농구장 제보 데이터 수정에 실패했습니다.</p>
+                    )}
+                  </ModalBody>
+                  <ModalFooter>
+                    <Button color="primary" onPress={handleEditClose}>
+                      확인
+                    </Button>
+                  </ModalFooter>
+                </>
+              )}
+            </ModalContent>
+          </Modal>
+        </div>
+      </>
+    );
+  }
+  return null;
+};
+
+export default EditAdminCourtDetails;

--- a/src/app/admin/components/EditAdminCourtDetails.tsx
+++ b/src/app/admin/components/EditAdminCourtDetails.tsx
@@ -87,7 +87,7 @@ const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
       formData.append('image', file);
     }
 
-    const finalData = convertCourtData(data);
+    const finalData = convertCourtData(data, previewUrl);
 
     formData.append(
       'data',

--- a/src/app/admin/components/EditAdminCourtDetails.tsx
+++ b/src/app/admin/components/EditAdminCourtDetails.tsx
@@ -122,9 +122,9 @@ const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
       <>
         <title>슬램톡 | 관리자</title>
         <div
-          className={`absolute inset-0 z-20 m-auto w-full max-w-md overflow-y-auto rounded-lg
+          className="fixed inset-0 z-20 m-auto h-full w-full max-w-md overflow-y-auto rounded-lg
     bg-background text-sm shadow-md transition-all duration-300 ease-in-out
-    md:max-h-[90vh] md:text-lg lg:text-xl`}
+    sm:max-h-[85vh] md:max-h-[90vh] md:text-lg lg:text-xl"
         >
           <div className="relative h-full overflow-y-auto">
             <div className="sticky top-0 z-30 flex h-14 w-full items-center justify-center border-b bg-background">
@@ -299,7 +299,9 @@ const EditAdminCourtDetails: React.FC<EditAdminCourtDetailsProps> = ({
                   />
                 </div>
                 <Select
-                  defaultSelectedKeys={data.convenience || []}
+                  defaultSelectedKeys={
+                    data.convenience?.filter((item) => item !== '') || []
+                  }
                   className="z-10 font-semibold"
                   radius="sm"
                   labelPlacement="outside"

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,7 +9,6 @@ import {
   TableBody,
   TableRow,
   TableCell,
-  Pagination,
 } from '@nextui-org/react';
 import getReportedCourtData from '@/services/admin/getReportedCourtData';
 import { BasketballCourtReportAdmin } from '@/types/basketballCourt/basketballCourtReport';
@@ -35,10 +34,8 @@ const columns = [
     label: '상태',
   },
 ];
-const ITEMS_PER_PAGE = 10; // 예를 들어, 페이지당 2개의 아이템
 
 const AdminPage = () => {
-  const [currentPage, setCurrentPage] = useState(1);
   const [isCourtDetailsVisible, setIsCourtDetailsVisible] = useState(false);
   const [selectedCourt, setSelectedCourt] =
     useState<BasketballCourtReportAdmin | null>(null);
@@ -59,87 +56,72 @@ const AdminPage = () => {
     setIsCourtDetailsVisible(false);
   };
 
-  if (reportedData) {
-    const currentData = reportedData.slice(
-      (currentPage - 1) * ITEMS_PER_PAGE,
-      currentPage * ITEMS_PER_PAGE
-    );
-
-    const handleEditClose = () => {
-      setEditMode(false);
-      refetch();
-    };
-
+  if (!reportedData) {
     return (
-      <div className="relative h-[calc(100vh-109px)] w-full max-w-[600px] overflow-y-scroll">
-        <title>슬램톡 | 관리자</title>
-        <Table
-          aria-label="농구장 제보 목록"
-          fullWidth
-          classNames={{
-            wrapper: 'h-full min-h-[810px] sm:min-h-[637px]',
-          }}
-          bottomContent={
-            <div className="flex w-full justify-center">
-              <Pagination
-                total={Math.ceil(reportedData.length / ITEMS_PER_PAGE)}
-                initialPage={1}
-                onChange={(page) => setCurrentPage(page)}
-              />
-            </div>
-          }
-        >
-          <TableHeader>
-            {columns.map((column) => (
-              <TableColumn key={column.key}>{column.label}</TableColumn>
-            ))}
-          </TableHeader>
-          <TableBody items={reportedData}>
-            {currentData.map((item: BasketballCourtReportAdmin) => (
-              <TableRow key={item.courtId}>
-                {columns.map((column) => (
-                  <TableCell key={`${column.key}`}>
-                    {column.key === 'informerId' ? (
-                      <AdminUserAvatar userId={item.informerId} />
-                    ) : (
-                      <div
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => handleCourtDetailClick(item)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') {
-                            handleCourtDetailClick(item);
-                          }
-                        }}
-                      >
-                        {item[column.key as keyof BasketballCourtReportAdmin]}
-                      </div>
-                    )}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-        {isCourtDetailsVisible && selectedCourt && !editMode && (
-          <AdminCourtDetails
-            data={selectedCourt}
-            handleCloseDetails={() => setIsCourtDetailsVisible(false)}
-            handleEditMode={handleEditMode}
-            refetch={refetch}
-          />
-        )}
-        {editMode && selectedCourt && (
-          <EditAdminCourtDetails
-            data={selectedCourt}
-            handleEditClose={handleEditClose}
-          />
-        )}
+      <div className="mt-60 w-full text-center">
+        제보받은 농구장이 없습니다.
       </div>
     );
   }
+
+  const handleEditClose = () => {
+    setEditMode(false);
+    refetch();
+  };
+
   return (
-    <div className="mt-20 w-full text-center">제보받은 농구장이 없습니다.</div>
+    <div
+      className={`relative h-[calc(100vh-109px)] w-full ${isCourtDetailsVisible || editMode ? 'overflow-y-hidden' : 'overflow-y-scroll'}`}
+    >
+      <title>슬램톡 | 관리자</title>
+      <Table isHeaderSticky aria-label="농구장 제보 목록" fullWidth>
+        <TableHeader>
+          {columns.map((column) => (
+            <TableColumn key={column.key}>{column.label}</TableColumn>
+          ))}
+        </TableHeader>
+        <TableBody items={reportedData}>
+          {reportedData.map((item: BasketballCourtReportAdmin) => (
+            <TableRow key={item.courtId}>
+              {columns.map((column) => (
+                <TableCell key={`${column.key}`}>
+                  {column.key === 'informerId' ? (
+                    <AdminUserAvatar userId={item.informerId} />
+                  ) : (
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => handleCourtDetailClick(item)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          handleCourtDetailClick(item);
+                        }
+                      }}
+                    >
+                      {item[column.key as keyof BasketballCourtReportAdmin]}
+                    </div>
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {isCourtDetailsVisible && selectedCourt && !editMode && (
+        <AdminCourtDetails
+          data={selectedCourt}
+          handleCloseDetails={() => setIsCourtDetailsVisible(false)}
+          handleEditMode={handleEditMode}
+          refetch={refetch}
+        />
+      )}
+      {editMode && selectedCourt && (
+        <EditAdminCourtDetails
+          data={selectedCourt}
+          handleEditClose={handleEditClose}
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,6 +15,7 @@ import getReportedCourtData from '@/services/admin/getReportedCourtData';
 import { BasketballCourtReportAdmin } from '@/types/basketballCourt/basketballCourtReport';
 import AdminCourtDetails from './components/AdminCourtDetails';
 import AdminUserAvatar from './components/AdminUserAvatar';
+import EditAdminCourtDetails from './components/EditAdminCourtDetails';
 
 const columns = [
   {
@@ -41,6 +42,7 @@ const AdminPage = () => {
   const [isCourtDetailsVisible, setIsCourtDetailsVisible] = useState(false);
   const [selectedCourt, setSelectedCourt] =
     useState<BasketballCourtReportAdmin | null>(null);
+  const [editMode, setEditMode] = useState(false);
 
   const { data: reportedData, refetch } = useQuery({
     queryKey: ['reportedData'],
@@ -52,11 +54,21 @@ const AdminPage = () => {
     setSelectedCourt(item);
   };
 
+  const handleEditMode = () => {
+    setEditMode(true);
+    setIsCourtDetailsVisible(false);
+  };
+
   if (reportedData) {
     const currentData = reportedData.slice(
       (currentPage - 1) * ITEMS_PER_PAGE,
       currentPage * ITEMS_PER_PAGE
     );
+
+    const handleEditClose = () => {
+      setEditMode(false);
+      refetch();
+    };
 
     return (
       <div className="relative h-[calc(100vh-109px)] w-full max-w-[600px] overflow-y-scroll">
@@ -109,11 +121,18 @@ const AdminPage = () => {
             ))}
           </TableBody>
         </Table>
-        {isCourtDetailsVisible && selectedCourt && (
+        {isCourtDetailsVisible && selectedCourt && !editMode && (
           <AdminCourtDetails
             data={selectedCourt}
-            onClose={() => setIsCourtDetailsVisible(false)}
+            handleCloseDetails={() => setIsCourtDetailsVisible(false)}
+            handleEditMode={handleEditMode}
             refetch={refetch}
+          />
+        )}
+        {editMode && selectedCourt && (
+          <EditAdminCourtDetails
+            data={selectedCourt}
+            handleEditClose={handleEditClose}
           />
         )}
       </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -29,10 +29,6 @@ const columns = [
     key: 'address',
     label: '위치',
   },
-  {
-    key: 'status',
-    label: '상태',
-  },
 ];
 
 const AdminPage = () => {

--- a/src/app/map/components/CourtDetails.tsx
+++ b/src/app/map/components/CourtDetails.tsx
@@ -286,8 +286,9 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                   />
                   <ul className="flex gap-2">
                     {selectedPlace.convenience &&
-                      selectedPlace.convenience.map(
-                        (tag: string, idx: number) =>
+                      selectedPlace.convenience
+                        .filter((item) => item !== '')
+                        .map((tag: string, idx: number) =>
                           tag !== '' ? (
                             <li
                               // eslint-disable-next-line react/no-array-index-key
@@ -299,7 +300,7 @@ const CourtDetails: React.FC<CourtDetailsProps> = ({
                           ) : (
                             '-'
                           )
-                      )}
+                        )}
                   </ul>
                 </div>
                 <div className="flex items-center gap-2 align-middle">

--- a/src/app/map/components/CourtDetailsFull.tsx
+++ b/src/app/map/components/CourtDetailsFull.tsx
@@ -236,8 +236,9 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                   />
                   <ul className="flex gap-2">
                     {selectedPlace.convenience &&
-                      selectedPlace.convenience.map(
-                        (tag: string, idx: number) =>
+                      selectedPlace.convenience
+                        .filter((item) => item !== '')
+                        .map((tag: string, idx: number) =>
                           tag !== '' ? (
                             <li
                               // eslint-disable-next-line react/no-array-index-key
@@ -249,7 +250,7 @@ const CourtDetailsFull: React.FC<CourtDetailsProps> = ({ courtId }) => {
                           ) : (
                             '-'
                           )
-                      )}
+                        )}
                   </ul>
                 </div>
                 <div className="flex items-center gap-2 align-middle">

--- a/src/app/map/components/CourtReport.tsx
+++ b/src/app/map/components/CourtReport.tsx
@@ -63,6 +63,7 @@ const CourtReport: React.FC<CourtReportProps> = ({
 
     const finalData = {
       ...data,
+      indoorOutdoor: data.indoorOutdoor || null,
       address,
       latitude: position.lat,
       longitude: position.lng,

--- a/src/app/map/components/CourtReport.tsx
+++ b/src/app/map/components/CourtReport.tsx
@@ -83,7 +83,7 @@ const CourtReport: React.FC<CourtReportProps> = ({
         가능: 'PARKING_AVAILABLE',
         불가능: 'PARKING_UNAVAILABLE',
       }),
-      convenience: data.convenience ?? '',
+      convenience: data.convenience?.length ? data.convenience : null,
     };
 
     formData.append(

--- a/src/app/map/components/CourtReport.tsx
+++ b/src/app/map/components/CourtReport.tsx
@@ -73,7 +73,7 @@ const CourtReport: React.FC<CourtReportProps> = ({
       }),
       openingHours: mapValue(data.openingHours, {
         '24시': 'ALL_NIGHT',
-        제한: 'NON_ALL_LIGHT',
+        제한: 'NON_ALL_NIGHT',
       }),
       fee: mapValue(data.fee, {
         무료: 'FREE',

--- a/src/app/map/components/CourtReport.tsx
+++ b/src/app/map/components/CourtReport.tsx
@@ -28,6 +28,7 @@ import {
   basketballConvenience,
 } from '@/constants/courtReportData';
 import { BasketballCourtReport } from '@/types/basketballCourt/basketballCourtReport';
+import { mapValue } from '@/utils/convertCourtData';
 import { CameraIcon } from './icons/CameraIcon';
 
 interface CourtReportProps {
@@ -36,13 +37,6 @@ interface CourtReportProps {
   handleClose: () => void;
   onReportSuccess: () => void;
 }
-
-// 농구장 사진(1MB) ✅
-// (마커 정보→ 위도, 경도, 주소) ✅
-// 농구장명(필수), 주소(필수), 코트 종류, 실내외(실내/야외), 코트사이즈, 골대수, ✅
-// 야간 조명, 개방시간(제한/24시), 사용료, 주차 가능, 기타 정보 ✅
-// 전화번호, 홈페이지(링크), 편의시설 ✅
-// (도로명 주소 반영) ✅
 
 const CourtReport: React.FC<CourtReportProps> = ({
   position,
@@ -67,57 +61,28 @@ const CourtReport: React.FC<CourtReportProps> = ({
       formData.append('image', file);
     }
 
-    // nightLighting : 있음(LIGHT) , 없음(NON_LIGHT)
-    // openingHours : 24시(ALL_NIGHT), 제한(NON_ALL_NIGHT)
-    // fee : 무료(FREE) , 유료(NON_FREE)
-    // parkingAvailable : 가능(PARKING_AVAILABLE), 불가능(PARKING_UNAVAILABLE)
-
-    // 백엔드에 보낼 형식 맞추기
-    if (data.convenience?.length === 0) {
-      data.convenience = null;
-    }
-
-    if (data.indoorOutdoor === undefined) {
-      data.indoorOutdoor = null;
-    }
-
-    if (data.nightLighting === '있음') {
-      data.nightLighting = 'LIGHT';
-    } else if (data.nightLighting === '없음') {
-      data.nightLighting = 'NON_LIGHT';
-    } else {
-      data.nightLighting = null;
-    }
-
-    if (data.openingHours === '24시') {
-      data.openingHours = 'ALL_NIGHT';
-    } else if (data.openingHours === '제한') {
-      data.openingHours = 'NON_ALL_LIGHT';
-    } else {
-      data.openingHours = null;
-    }
-
-    if (data.fee === '무료') {
-      data.fee = 'FREE';
-    } else if (data.fee === '유료') {
-      data.fee = 'NON_FREE';
-    } else {
-      data.fee = null;
-    }
-
-    if (data.parkingAvailable === '가능') {
-      data.parkingAvailable = 'PARKING_AVAILABLE';
-    } else if (data.parkingAvailable === '불가능') {
-      data.parkingAvailable = 'PARKING_UNAVAILABLE';
-    } else {
-      data.parkingAvailable = null;
-    }
-
     const finalData = {
       ...data,
       address,
       latitude: position.lat,
       longitude: position.lng,
+      nightLighting: mapValue(data.nightLighting, {
+        있음: 'LIGHT',
+        없음: 'NON_LIGHT',
+      }),
+      openingHours: mapValue(data.openingHours, {
+        '24시': 'ALL_NIGHT',
+        제한: 'NON_ALL_LIGHT',
+      }),
+      fee: mapValue(data.fee, {
+        무료: 'FREE',
+        유료: 'NON_FREE',
+      }),
+      parkingAvailable: mapValue(data.parkingAvailable, {
+        가능: 'PARKING_AVAILABLE',
+        불가능: 'PARKING_UNAVAILABLE',
+      }),
+      convenience: data.convenience ?? '',
     };
 
     formData.append(

--- a/src/app/map/components/CourtReportDetails.tsx
+++ b/src/app/map/components/CourtReportDetails.tsx
@@ -219,8 +219,9 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                   />
                   <ul className="flex gap-2">
                     {selectedPlace.convenience?.length
-                      ? selectedPlace.convenience.map(
-                          (tag: string, idx: number) => (
+                      ? selectedPlace.convenience
+                          .filter((item) => item !== '')
+                          .map((tag: string, idx: number) => (
                             <li
                               // eslint-disable-next-line react/no-array-index-key
                               key={idx}
@@ -228,8 +229,7 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                             >
                               <span>{tag}</span>
                             </li>
-                          )
-                        )
+                          ))
                       : '-'}
                   </ul>
                 </div>

--- a/src/app/map/components/CourtReportDetails.tsx
+++ b/src/app/map/components/CourtReportDetails.tsx
@@ -131,7 +131,9 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                   <span>
                     개방 시간:{' '}
                     <span className="text-rose-400">
-                      {selectedPlace.openingHours}
+                      {selectedPlace.openingHours === '정보없음'
+                        ? '-'
+                        : selectedPlace.openingHours}
                     </span>
                   </span>
                 </div>
@@ -147,7 +149,8 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                 <div className="flex items-center gap-2 align-middle">
                   <FeeIcon className="text-gray-400 dark:text-gray-200" />
                   <span className="text-info text-blue-500">
-                    이용료: {selectedPlace.fee}
+                    이용료:{' '}
+                    {selectedPlace.fee === '정보없음' ? '-' : selectedPlace.fee}
                   </span>
                 </div>
 
@@ -189,14 +192,24 @@ const CourtReportDetails: React.FC<CourtDetailsProps> = ({
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
                   />
-                  <span>야간 조명: {selectedPlace.nightLighting}</span>
+                  <span>
+                    야간 조명:{' '}
+                    {selectedPlace.nightLighting === '정보없음'
+                      ? '-'
+                      : selectedPlace.nightLighting}
+                  </span>
                 </div>
                 <div className="flex items-center gap-2 align-middle">
                   <FaParking
                     size={17}
                     className="text-gray-400 dark:text-gray-200"
                   />
-                  <span>주차: {selectedPlace.parkingAvailable}</span>
+                  <span>
+                    주차:{' '}
+                    {selectedPlace.parkingAvailable === '정보없음'
+                      ? '-'
+                      : selectedPlace.parkingAvailable}
+                  </span>
                 </div>
 
                 <div className="flex items-center gap-2 align-middle text-sm">

--- a/src/services/basketballCourt/getCourtDetails.ts
+++ b/src/services/basketballCourt/getCourtDetails.ts
@@ -28,7 +28,6 @@ const getCourtDetails = async (courtId: number) => {
         additionalInfo: court.additionalInfo,
         photoUrl: court.photoUrl,
         informerId: court.informerId,
-        adminStatus: court.adminStatus,
         chatroomId: court.chatroomId,
       };
       return courtDetails;

--- a/src/services/basketballCourt/getCourtDetails.ts
+++ b/src/services/basketballCourt/getCourtDetails.ts
@@ -27,6 +27,8 @@ const getCourtDetails = async (courtId: number) => {
         convenience: court.convenience,
         additionalInfo: court.additionalInfo,
         photoUrl: court.photoUrl,
+        informerId: court.informerId,
+        adminStatus: court.adminStatus,
         chatroomId: court.chatroomId,
       };
       return courtDetails;

--- a/src/services/basketballCourt/getReportCourtDetails.ts
+++ b/src/services/basketballCourt/getReportCourtDetails.ts
@@ -29,6 +29,7 @@ const getReportCourtDetails = async (courtId: number) => {
         convenience: court.convenience,
         additionalInfo: court.additionalInfo,
         photoUrl: court.photoUrl,
+        informerId: court.informerId,
         chatroomId: court.chatroomId,
       };
       return courtDetails;

--- a/src/types/basketballCourt/basketballCourtReport.ts
+++ b/src/types/basketballCourt/basketballCourtReport.ts
@@ -27,5 +27,5 @@ export interface BasketballCourtReportAdmin
 
 export interface ConvertedCourtData
   extends Omit<BasketballCourtReportAdmin, 'convenience'> {
-  convenience: string[];
+  convenience: string;
 }

--- a/src/types/basketballCourt/basketballCourtReport.ts
+++ b/src/types/basketballCourt/basketballCourtReport.ts
@@ -21,7 +21,7 @@ export interface BasketballCourtReport {
 export interface BasketballCourtReportAdmin
   extends Omit<BasketballCourtReport, 'file'> {
   courtId: number;
-  photoUrl: string;
+  photoUrl: string | null;
   informerId: number;
 }
 

--- a/src/types/basketballCourt/basketballCourtReport.ts
+++ b/src/types/basketballCourt/basketballCourtReport.ts
@@ -8,10 +8,10 @@ export interface BasketballCourtReport {
   indoorOutdoor: string | null;
   courtSize: string | null;
   hoopCount: number | null;
-  nightLighting: string | null; // default: 없음
-  openingHours: string | null; // 제한
-  fee: string | null; // 무료
-  parkingAvailable: string | null; // 불가능
+  nightLighting: string | null;
+  openingHours: string | null;
+  fee: string | null;
+  parkingAvailable: string | null;
   phoneNum: string | null;
   website: string | null;
   convenience: string[] | null;
@@ -23,4 +23,9 @@ export interface BasketballCourtReportAdmin
   courtId: number;
   photoUrl: string;
   informerId: number;
+}
+
+export interface ConvertedCourtData
+  extends Omit<BasketballCourtReportAdmin, 'convenience'> {
+  convenience: string;
 }

--- a/src/types/basketballCourt/basketballCourtReport.ts
+++ b/src/types/basketballCourt/basketballCourtReport.ts
@@ -27,5 +27,5 @@ export interface BasketballCourtReportAdmin
 
 export interface ConvertedCourtData
   extends Omit<BasketballCourtReportAdmin, 'convenience'> {
-  convenience: string;
+  convenience: string[];
 }

--- a/src/types/basketballCourt/basketballCourtsDetails.ts
+++ b/src/types/basketballCourt/basketballCourtsDetails.ts
@@ -8,14 +8,15 @@ export interface BasketballCourtsDetails {
   indoorOutdoor: string;
   courtSize: string;
   hoopCount: number;
-  nightLighting: boolean;
-  openingHours: boolean;
-  fee: boolean;
-  parkingAvailable: boolean;
+  nightLighting: string;
+  openingHours: string;
+  fee: string;
+  parkingAvailable: string;
   phoneNum: string | null;
   website: string | null;
   convenience: string[] | null;
   additionalInfo: string | null;
   photoUrl: string | null;
+  informerId: number;
   chatroomId: number;
 }

--- a/src/types/chat/createChatRoom.ts
+++ b/src/types/chat/createChatRoom.ts
@@ -5,8 +5,3 @@ export interface ICreateChatRoom {
   basket_ball_id: number;
   name: string;
 }
-
-export interface ICreateCourtChatRoom {
-  basket_ball_id: number;
-  name: string;
-}

--- a/src/utils/convertCourtData.ts
+++ b/src/utils/convertCourtData.ts
@@ -41,7 +41,9 @@ export const convertCourtData = (
   }),
   phoneNum: data.phoneNum,
   website: data.website,
-  convenience: data.convenience ?? [],
+  convenience: Array.isArray(data.convenience)
+    ? data.convenience.join(',')
+    : data.convenience || '',
   photoUrl: data.photoUrl ?? null,
   additionalInfo: data.additionalInfo,
   informerId: data.informerId,

--- a/src/utils/convertCourtData.ts
+++ b/src/utils/convertCourtData.ts
@@ -20,7 +20,7 @@ export const convertCourtData = (
   latitude: data.latitude,
   longitude: data.longitude,
   courtType: data.courtType,
-  indoorOutdoor: data.indoorOutdoor,
+  indoorOutdoor: data.indoorOutdoor || null,
   courtSize: data.courtSize,
   hoopCount: data.hoopCount,
   nightLighting: mapValue(data.nightLighting, {
@@ -41,7 +41,7 @@ export const convertCourtData = (
   }),
   phoneNum: data.phoneNum,
   website: data.website,
-  convenience: data.convenience?.join(', ') ?? '',
+  convenience: data.convenience ?? [],
   photoUrl: data.photoUrl ?? null,
   additionalInfo: data.additionalInfo,
   informerId: data.informerId,

--- a/src/utils/convertCourtData.ts
+++ b/src/utils/convertCourtData.ts
@@ -1,0 +1,48 @@
+import {
+  BasketballCourtReportAdmin,
+  ConvertedCourtData,
+} from '@/types/basketballCourt/basketballCourtReport';
+
+export const mapValue = (
+  value: string | null,
+  mapping: { [key: string]: string }
+): string | null => {
+  if (value === null) return null;
+  return mapping[value] || null;
+};
+
+export const convertCourtData = (
+  data: BasketballCourtReportAdmin
+): ConvertedCourtData => ({
+  courtId: data.courtId,
+  courtName: data.courtName,
+  address: data.address,
+  latitude: data.latitude,
+  longitude: data.longitude,
+  courtType: data.courtType,
+  indoorOutdoor: data.indoorOutdoor,
+  courtSize: data.courtSize,
+  hoopCount: data.hoopCount,
+  nightLighting: mapValue(data.nightLighting, {
+    있음: 'LIGHT',
+    없음: 'NON_LIGHT',
+  }),
+  openingHours: mapValue(data.openingHours, {
+    '24시': 'ALL_NIGHT',
+    제한: 'NON_ALL_LIGHT',
+  }),
+  fee: mapValue(data.fee, {
+    무료: 'FREE',
+    유료: 'NON_FREE',
+  }),
+  parkingAvailable: mapValue(data.parkingAvailable, {
+    가능: 'PARKING_AVAILABLE',
+    불가능: 'PARKING_UNAVAILABLE',
+  }),
+  phoneNum: data.phoneNum,
+  website: data.website,
+  convenience: data.convenience?.join(', ') ?? '',
+  photoUrl: data.photoUrl ?? null,
+  additionalInfo: data.additionalInfo,
+  informerId: data.informerId,
+});

--- a/src/utils/convertCourtData.ts
+++ b/src/utils/convertCourtData.ts
@@ -30,7 +30,7 @@ export const convertCourtData = (
   }),
   openingHours: mapValue(data.openingHours, {
     '24시': 'ALL_NIGHT',
-    제한: 'NON_ALL_LIGHT',
+    제한: 'NON_ALL_NIGHT',
   }),
   fee: mapValue(data.fee, {
     무료: 'FREE',

--- a/src/utils/convertCourtData.ts
+++ b/src/utils/convertCourtData.ts
@@ -12,7 +12,8 @@ export const mapValue = (
 };
 
 export const convertCourtData = (
-  data: BasketballCourtReportAdmin
+  data: BasketballCourtReportAdmin,
+  previewUrl: string | null
 ): ConvertedCourtData => ({
   courtId: data.courtId,
   courtName: data.courtName,
@@ -44,7 +45,7 @@ export const convertCourtData = (
   convenience: Array.isArray(data.convenience)
     ? data.convenience.join(',')
     : data.convenience || '',
-  photoUrl: data.photoUrl ?? null,
+  photoUrl: previewUrl,
   additionalInfo: data.additionalInfo,
   informerId: data.informerId,
 });


### PR DESCRIPTION
## 📝 작업 내용

> 백엔드 리팩토링에 따른 농구장 제보 관련 타입 수정 관련 이슈가 많아 수정했습니다. 현재 **'야간조명, 개방시간, 사용료, 주차여부'** 데이터 제보, 제보 데이터 수정시 '**정보없음**'으로만 들어가는 버그가 있어서 백엔드쪽 확인 중입니다. 수정 완료 전까지 제대로 된 내용이 들어가지 않아서 제보 수락은 미뤄주세요.

> 모바일, 데스크탑 각 기기에 맞게 동적으로 테이블 스타일링, 페이지네이션이 안되고 있어 삭제하고 전체 스크롤로 일단 넣었습니다. 관리자 페이지에서 자세히 보기, 수정 컴포넌트를 열면 부모 스크롤이 안보이게 스타일링 했습니다.

- [x] 타입 수정
- [x] 농구장 제보 거절, 수락 로직 업데이트
- [x] 페이지네이션 삭제, 전체 스크롤 스타일링
- [x] 농구장 데이터 수정 컴포넌트 연결

## 💬 리뷰 요구사항
  > 백엔드쪽이 같이 확인이 안되서 관리자 페이지 수정이 늦었습니다. 버그 수정 완료되면 말씀드릴게요. 그때부터 자유롭게 제보 데이터 수락, 수정 해주세요 :)
  > 시간날 때 개선하고 싶은 부분 유지 보수할 예정입니다. 자유롭게 다른 분들도 개선하고 싶은 부분 PR 보내주세요. 저희 lighthouse 돌려보면 전체적으로 성능이 괜찮더라구여 한 번 확인해보는거 추천드립니당~~
  
 -> 잘못된 데이터 타입 들어가는 오류 수정 완료했습니다 제보 자유롭게 편집, 수락 해주세요~~
